### PR TITLE
Refactor notifier test

### DIFF
--- a/tests/test_notifier.py
+++ b/tests/test_notifier.py
@@ -1,15 +1,25 @@
+import importlib
 import os
-from dotenv import load_dotenv
-load_dotenv()
-from notifications.notifier import kirim_notifikasi_telegram
-assert os.getenv("TELEGRAM_TOKEN"), "TELEGRAM_TOKEN belum ter-set"
-assert os.getenv("TELEGRAM_CHAT_ID"), "TELEGRAM_CHAT_ID belum ter-set"
+from unittest.mock import patch
 
 
 def test_notifier():
-    msg = "📈 *UNIT TEST* Notifikasi bot RajaDollar!"
-    kirim_notifikasi_telegram(msg)
-    print("Cek Telegram, notifikasi harus terkirim!")
+    with patch.dict(os.environ, {"TELEGRAM_TOKEN": "token", "TELEGRAM_CHAT_ID": "chat"}):
+        import notifications.notifier as notifier
+        importlib.reload(notifier)
+
+        with patch("notifications.notifier.requests.post") as mock_post:
+            msg = "📈 *UNIT TEST* Notifikasi bot RajaDollar!"
+            notifier.kirim_notifikasi_telegram(msg)
+
+            expected_url = "https://api.telegram.org/bottoken/sendMessage"
+            expected_data = {
+                "chat_id": "chat",
+                "text": msg,
+                "parse_mode": "Markdown",
+            }
+            mock_post.assert_called_once_with(expected_url, data=expected_data)
+
 
 if __name__ == "__main__":
     test_notifier()


### PR DESCRIPTION
## Summary
- mock `requests.post` in notifier tests
- remove environment variable checks

## Testing
- `pytest -q tests/test_notifier.py`
- `pytest -q` *(fails: ProxyError during Binance API calls)*

------
https://chatgpt.com/codex/tasks/task_e_6885f691c30083288a2ee814f2f6b1e8