### PR TITLE
Fix quantity adjustment for minNotional

### DIFF
--- a/execution/order_router.py
+++ b/execution/order_router.py
@@ -50,12 +50,24 @@ def adjust_quantity_to_min(symbol, quantity, price, symbol_filters):
     min_notional = float(filt.get('minNotional', 0.0))
     qty = max(quantity, min_qty)
     precision = int(-math.log10(step)) if step > 0 else 0
-    qty = math.floor(qty * (10 ** precision)) / (10 ** precision) if step > 0 else qty
-    # pastikan nilai minNotional
+
+    # round down to valid step size first
+    if step > 0:
+        qty = math.floor(qty / step) * step
+
+    # ensure notional requirement after rounding
     if min_notional > 0 and price * qty < min_notional:
         needed = min_notional / price
-        qty = max(qty, needed)
-        qty = math.floor(qty * (10 ** precision)) / (10 ** precision) if step > 0 else qty
+        if step > 0:
+            qty = math.ceil(needed / step) * step
+        else:
+            qty = needed
+        qty = max(qty, min_qty)
+
+    # final rounding to the allowed precision
+    if step > 0:
+        qty = round(qty, precision)
+
     return qty
 
 def get_mark_price(client, symbol):

--- a/tests/test_order_router.py
+++ b/tests/test_order_router.py
@@ -8,5 +8,14 @@ def test_adjust_quantity_to_min():
     assert qty >= 0.001  # minQty
     print("Qty after adjustment:", qty)
 
+def test_adjust_quantity_to_min_notional():
+    symbol_filters = {
+        "ETHUSDT": {"minQty": 0.001, "stepSize": 0.001, "minNotional": 5}
+    }
+    qty = adjust_quantity_to_min("ETHUSDT", 0.0025, 2000, symbol_filters)
+    assert qty * 2000 >= 5  # meets minNotional
+    assert qty == 0.003
+    print("Qty with notional check:", qty)
+
 if __name__ == "__main__":
     test_adjust_quantity_to_min()


### PR DESCRIPTION
## Summary
- ensure order quantity rounds up to satisfy `minNotional`
- test new edge case for notional-based adjustment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885f33408888328bb272e9b2cf3e11c