### PR TITLE
Fix trailing params and date handling

### DIFF
--- a/models/trade.py
+++ b/models/trade.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+
 @dataclass
 class Trade:
     symbol: str
@@ -14,6 +15,9 @@ class Trade:
     exit_time: str | None = None
     exit_price: float | None = None
     order_id: str | None = None   # Tambahkan field order_id
+    # Field tambahan untuk konfigurasi trailing stop
+    trailing_offset: float | None = None
+    trigger_threshold: float | None = None
 
     def to_dict(self):
         return self.__dict__

--- a/strategies/scalping_strategy.py
+++ b/strategies/scalping_strategy.py
@@ -3,7 +3,9 @@ from ta.trend import EMAIndicator, SMAIndicator, MACD
 from ta.momentum import RSIIndicator
 from ta.volatility import BollingerBands, AverageTrueRange
 
-def apply_indicators(df, config, bb_std=2):
+def apply_indicators(df, config=None, bb_std=2):
+    if config is None:
+        config = {}
     ema_period = config.get('ema_period', 14)
     sma_period = config.get('sma_period', 14)
     rsi_period = config.get('rsi_period', 14)


### PR DESCRIPTION
## Summary
- support trailing stop parameters in Trade dataclass
- create Trade objects using keywords
- improve date range typing
- make indicator config optional

## Testing
- `pytest -q` *(fails: ProxyError when contacting testnet.binance.vision)*

------
https://chatgpt.com/codex/tasks/task_e_6885fbde45888328a80c01b738823aad