### PR TITLE
Perbaiki impor library opsional

### DIFF
--- a/execution/order_router.py
+++ b/execution/order_router.py
@@ -1,4 +1,5 @@
-import math, logging
+import math
+import logging
 try:
     from binance.enums import (
         SIDE_BUY,

--- a/execution/order_router.py
+++ b/execution/order_router.py
@@ -1,5 +1,18 @@
 import math, logging
-from binance.enums import SIDE_BUY, SIDE_SELL, ORDER_TYPE_MARKET, ORDER_TYPE_LIMIT, TIME_IN_FORCE_GTC
+try:
+    from binance.enums import (
+        SIDE_BUY,
+        SIDE_SELL,
+        ORDER_TYPE_MARKET,
+        ORDER_TYPE_LIMIT,
+        TIME_IN_FORCE_GTC,
+    )
+except ModuleNotFoundError:  # fallback ketika python-binance tidak tersedia
+    SIDE_BUY = "BUY"
+    SIDE_SELL = "SELL"
+    ORDER_TYPE_MARKET = "MARKET"
+    ORDER_TYPE_LIMIT = "LIMIT"
+    TIME_IN_FORCE_GTC = "GTC"
 from execution.slippage_handler import verify_price_before_order
 from risk_management.risk_checker import is_liquidation_risk
 

--- a/execution/ws_signal_listener.py
+++ b/execution/ws_signal_listener.py
@@ -1,4 +1,3 @@
-import threading, json
 from binance import ThreadedWebsocketManager
 from utils.data_provider import fetch_latest_data
 from strategies.scalping_strategy import apply_indicators, generate_signals

--- a/notifications/notifier.py
+++ b/notifications/notifier.py
@@ -1,4 +1,13 @@
-import os, requests
+import os
+try:
+    import requests
+except ModuleNotFoundError:
+    from types import SimpleNamespace
+
+    def _missing_post(*args, **kwargs):
+        raise RuntimeError("requests library not available")
+
+    requests = SimpleNamespace(post=_missing_post)
 
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
 TELEGRAM_CHAT_ID = os.getenv("TELEGRAM_CHAT_ID")

--- a/utils/safe_api.py
+++ b/utils/safe_api.py
@@ -1,6 +1,11 @@
 import time
 import logging
-from binance.error import ClientError
+try:
+    from binance.error import ClientError
+except ModuleNotFoundError:
+    class ClientError(Exception):
+        """Fallback ClientError ketika modul binance tidak tersedia."""
+        pass
 
 _last_api_call = 0
 


### PR DESCRIPTION
## Ringkasan
- hindari kegagalan impor jika `python-binance` atau `requests` tidak tersedia
- tambah fallback ClientError di `utils.safe_api`

## Testing
- `pytest tests/test_notifier.py -q`
- `pytest tests/test_order_router.py -q`
- `pytest tests/test_safe_api.py -q`
- `pytest tests/test_risk_calculator.py -q`
- `pytest tests/test_position_manager.py -q`
- `pytest -q` *(gagal: ModuleNotFoundError untuk pandas, numpy dan binance)*

------
https://chatgpt.com/codex/tasks/task_e_6886258391348328a811469affe76ebb