### PR TITLE
Implement exit monitor worker

### DIFF
--- a/execution/monitor_exit_worker.py
+++ b/execution/monitor_exit_worker.py
@@ -1,0 +1,74 @@
+import threading
+import time
+from datetime import datetime
+from typing import Dict, Any
+
+from execution.order_router import safe_close_order_market
+from risk_management.position_manager import apply_trailing_sl, check_exit_condition
+from utils.state_manager import load_state, save_state
+from notifications.notifier import kirim_notifikasi_exit
+from database.sqlite_logger import log_trade
+from models.trade import Trade
+from execution.ws_listener import shared_price
+
+
+def process_exit_positions(client, symbol_steps: Dict[str, Any]):
+    active = load_state()
+    changed = False
+    for trade in active[:]:
+        symbol = trade["symbol"]
+        price = shared_price.get(symbol)
+        if price is None:
+            continue
+
+        trade["trailing_sl"] = apply_trailing_sl(
+            price,
+            trade["entry_price"],
+            trade["side"],
+            trade.get("trailing_sl", trade["sl"]),
+            trade.get("trigger_threshold", 0.5),
+            trade.get("trailing_offset", 0.25),
+        )
+
+        if check_exit_condition(
+            price,
+            trade["trailing_sl"],
+            trade["tp"],
+            trade["sl"],
+            direction=trade["side"],
+        ):
+            safe_close_order_market(
+                client,
+                symbol,
+                "SELL" if trade["side"] == "long" else "BUY",
+                trade["size"],
+                symbol_steps,
+            )
+            trade["exit_price"] = price
+            trade["exit_time"] = datetime.utcnow().isoformat()
+            trade["pnl"] = (
+                (price - trade["entry_price"]) * trade["size"]
+                if trade["side"] == "long"
+                else (trade["entry_price"] - price) * trade["size"]
+            )
+            kirim_notifikasi_exit(symbol, price, trade["pnl"], trade.get("order_id"))
+            log_trade(Trade(**trade))
+            active.remove(trade)
+            changed = True
+
+    if changed:
+        save_state(active)
+
+
+def start_exit_monitor(client, symbol_steps: Dict[str, Any] | None = None, interval: float = 1.0):
+    if symbol_steps is None:
+        symbol_steps = {}
+
+    def _worker():
+        while True:
+            process_exit_positions(client, symbol_steps)
+            time.sleep(interval)
+
+    th = threading.Thread(target=_worker, daemon=True)
+    th.start()
+    return th

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import os, json, timeit
 from binance.client import Client
 from execution.ws_listener import start_price_stream
 from execution.ws_signal_listener import start_signal_stream, register_signal_handler
+from execution.monitor_exit_worker import start_exit_monitor
 from utils.logger import setup_logger
 from execution.signal_entry import on_signal
 
@@ -84,6 +85,7 @@ st.sidebar.markdown(f"📶 Latency: `{lat} ms`" if lat else "❌ Ping gagal")
 
 start_price_stream(api_key, api_secret, multi_symbols)
 start_signal_stream(api_key, api_secret, client, multi_symbols, strategy_params)
+start_exit_monitor(client)
 
 # --- WebSocket Signal Handler ---
 

--- a/tests/test_monitor_exit_worker.py
+++ b/tests/test_monitor_exit_worker.py
@@ -1,0 +1,48 @@
+from unittest.mock import MagicMock
+from execution.monitor_exit_worker import process_exit_positions
+
+
+def test_process_exit_positions(monkeypatch):
+    trade = {
+        "symbol": "BTCUSDT",
+        "side": "long",
+        "entry_time": "2021-01-01T00:00:00",
+        "entry_price": 100.0,
+        "size": 0.1,
+        "sl": 95.0,
+        "tp": 105.0,
+        "trailing_sl": 95.0,
+        "order_id": "1",
+        "trailing_offset": 0.25,
+        "trigger_threshold": 0.5,
+    }
+
+    monkeypatch.setattr(
+        "execution.monitor_exit_worker.shared_price", {"BTCUSDT": 105.0}
+    )
+    monkeypatch.setattr(
+        "execution.monitor_exit_worker.load_state", lambda: [trade.copy()]
+    )
+    saved = {}
+
+    def save_state_stub(data):
+        saved["data"] = data
+
+    monkeypatch.setattr(
+        "execution.monitor_exit_worker.save_state", save_state_stub
+    )
+    monkeypatch.setattr(
+        "execution.monitor_exit_worker.safe_close_order_market", lambda *a, **kw: None
+    )
+    notif = MagicMock()
+    monkeypatch.setattr(
+        "execution.monitor_exit_worker.kirim_notifikasi_exit", notif
+    )
+    log = MagicMock()
+    monkeypatch.setattr("execution.monitor_exit_worker.log_trade", log)
+
+    process_exit_positions(MagicMock(), {})
+
+    assert saved["data"] == []
+    assert notif.called
+    assert log.called


### PR DESCRIPTION
## Summary
- tambahkan modul `monitor_exit_worker.py` untuk memonitor posisi aktif
- panggil `start_exit_monitor` dari `main.py`
- buat unit test `test_monitor_exit_worker.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68865fb483888328b336af29bfc67512