### PR TITLE
Implement resume notification and test

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from execution.ws_signal_listener import start_signal_stream, register_signal_ha
 from execution.monitor_exit_worker import start_exit_monitor
 from utils.logger import setup_logger
 from execution.signal_entry import on_signal
+from utils.resume_helper import handle_resume
 
 # --- Modular Imports ---
 from config import BINANCE_KEYS
@@ -84,6 +85,9 @@ lat = ping_latency(client)
 st.sidebar.markdown(f"📶 Latency: `{lat} ms`" if lat else "❌ Ping gagal")
 
 start_price_stream(api_key, api_secret, multi_symbols)
+active_positions = handle_resume(resume_flag, notif_resume)
+if resume_flag and active_positions:
+    st.sidebar.success(f"Resume {len(active_positions)} posisi aktif")
 start_signal_stream(api_key, api_secret, client, multi_symbols, strategy_params)
 start_exit_monitor(client)
 

--- a/tests/utils/test_resume_helper.py
+++ b/tests/utils/test_resume_helper.py
@@ -1,0 +1,23 @@
+from utils.resume_helper import handle_resume
+
+
+def test_handle_resume_with_active(monkeypatch):
+    monkeypatch.setattr("utils.resume_helper.load_state", lambda: [{"symbol": "BTC"}])
+    sent = {}
+    def send(msg):
+        sent["msg"] = msg
+    monkeypatch.setattr("utils.resume_helper.kirim_notifikasi_telegram", send)
+
+    active = handle_resume(True, True)
+    assert len(active) == 1
+    assert sent["msg"] == "🔄 Bot resumed with 1 active positions"
+
+
+def test_handle_resume_no_notify(monkeypatch):
+    monkeypatch.setattr("utils.resume_helper.load_state", lambda: [])
+    called = {}
+    monkeypatch.setattr("utils.resume_helper.kirim_notifikasi_telegram", lambda msg: called.setdefault("msg", msg))
+
+    active = handle_resume(True, True)
+    assert active == []
+    assert "msg" not in called

--- a/utils/resume_helper.py
+++ b/utils/resume_helper.py
@@ -1,0 +1,16 @@
+from utils.state_manager import load_state
+from notifications.notifier import kirim_notifikasi_telegram
+
+
+def handle_resume(resume_flag: bool, notif_resume: bool) -> list:
+    """Load saved positions and optionally send Telegram notification.
+
+    Returns the list of active positions loaded from state.
+    """
+    if not resume_flag:
+        return []
+
+    active = load_state()
+    if active and notif_resume:
+        kirim_notifikasi_telegram(f"🔄 Bot resumed with {len(active)} active positions")
+    return active


### PR DESCRIPTION
## Summary
- tambahkan util `handle_resume` untuk memuat state dan kirim notifikasi
- panggil `handle_resume` di `main.py` saat startup
- tampilkan pesan di sidebar jika posisi di-resume
- tambah unit test `test_resume_helper`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886661804448328b5d7be5d5bb93f94