### PR TITLE
Penguatan Rate Limiter Binance

### DIFF
--- a/execution/slippage_handler.py
+++ b/execution/slippage_handler.py
@@ -1,12 +1,12 @@
+from utils.safe_api import safe_api_call_with_retry
+
+
 def verify_price_before_order(client, symbol, side, expected_price, max_slippage=0.005):
-    """
-    Verifikasi slippage harga sebelum order dieksekusi.
-    """
-    try:
-        ticker = client.futures_symbol_ticker(symbol=symbol)
-        current_price = float(ticker['price'])
-    except Exception as e:
-        print(f"Error getting price: {e}")
+    """Verifikasi slippage harga sebelum order dieksekusi."""
+    ticker = safe_api_call_with_retry(client.futures_symbol_ticker, symbol=symbol)
+    if not ticker:
+        print("Error getting price")
         return False
+    current_price = float(ticker['price'])
     diff = abs(current_price - expected_price) / expected_price
     return diff <= max_slippage

--- a/tests/utils/test_safe_api_call.py
+++ b/tests/utils/test_safe_api_call.py
@@ -1,0 +1,27 @@
+import logging
+from utils.safe_api import safe_api_call_with_retry, ClientError
+
+
+def test_safe_api_call_with_retry(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_api():
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise ClientError("429", None)
+        return 42
+
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    result = safe_api_call_with_retry(fake_api, retries=3, delay=0)
+    assert result == 42
+    assert calls["n"] == 2
+
+
+def test_safe_api_call_with_retry_fail(monkeypatch):
+    def fake_api():
+        raise ClientError("429", None)
+
+    monkeypatch.setattr("time.sleep", lambda x: None)
+    result = safe_api_call_with_retry(fake_api, retries=2, delay=0)
+    assert result is None
+


### PR DESCRIPTION
## Ringkasan
- perkuat safe_api_call_with_retry dengan logging dan throttle
- semua akses Binance API dibungkus safe_api_call_with_retry
- tambah test mock untuk safe_api_call_with_retry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886690778ac832886b573e2af4d1085