### PR TITLE
Perbaikan risk calculator dan tambahan unit test

### DIFF
--- a/risk_management/risk_calculator.py
+++ b/risk_management/risk_calculator.py
@@ -1,7 +1,13 @@
+"""Perhitungan ukuran order berdasarkan risiko per transaksi."""
+
+
 def calculate_order_qty(symbol, entry_price, sl, capital, risk_per_trade, leverage):
+    """Hitung jumlah kontrak yang dibeli dengan model fixed fractional."""
     risk_amount = capital * risk_per_trade
     risk_per_pip = abs(entry_price - sl) * leverage
+
     if risk_per_pip == 0:
         return 0
+
     qty = risk_amount / risk_per_pip
     return max(0, qty)

--- a/tests/risk_management/test_order_sizing.py
+++ b/tests/risk_management/test_order_sizing.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+from risk_management.risk_calculator import calculate_order_qty
+
+
+def test_qty_basic():
+    qty = calculate_order_qty(
+        "BTCUSDT", entry_price=100, sl=99, capital=1000,
+        risk_per_trade=0.02, leverage=20
+    )
+    assert round(qty, 6) == 1.0
+
+
+def test_qty_zero_diff():
+    qty = calculate_order_qty(
+        "BTCUSDT", entry_price=100, sl=100, capital=1000,
+        risk_per_trade=0.02, leverage=20
+    )
+    assert qty == 0
+
+


### PR DESCRIPTION
## Ringkasan
- tambahkan dokumentasi singkat dan newline pada `risk_calculator.py`
- buat folder `tests/risk_management` dengan dua test untuk `calculate_order_qty`

## Hasil Pengujian
- `pytest -q` semua test: **pass**


------
https://chatgpt.com/codex/tasks/task_e_68866c3eedfc83289aeb099c913e8897