### PR TITLE
Refaktor websocket async

### DIFF
--- a/execution/ws_signal_listener.py
+++ b/execution/ws_signal_listener.py
@@ -1,51 +1,58 @@
-from binance import ThreadedWebsocketManager
+import asyncio
+from binance.streams import BinanceSocketManager
 import streamlit as st
 from utils.data_provider import fetch_latest_data
 from strategies.scalping_strategy import apply_indicators, generate_signals
 import utils.bot_flags as bot_flags
 
 signal_callbacks = {}
-ws_manager = None
+ws_manager: BinanceSocketManager | None = None
 client_global = None
+_tasks: dict[str, asyncio.Task] = {}
 
 def register_signal_handler(symbol: str, callback):
     signal_callbacks[symbol.upper()] = callback
 
 def start_signal_stream(api_key, api_secret, client, symbols: list[str], strategy_params):
-    global ws_manager, client_global
-    if not bot_flags.IS_READY:
-        print("Bot belum siap, signal stream tidak dimulai")
+    global ws_manager, client_global, _tasks
+    if not bot_flags.IS_READY or _tasks:
+        if not bot_flags.IS_READY:
+            print("Bot belum siap, signal stream tidak dimulai")
         return
     client_global = client
-    ws_manager = ThreadedWebsocketManager(api_key=api_key, api_secret=api_secret)
-    try:
-        ws_manager.start()
-    except Exception as e:
-        print(f"WebSocket signal error: {e}")
-        return
+    ws_manager = BinanceSocketManager(api_key=api_key, api_secret=api_secret)
 
-    def handle_kline(msg):
-        if st.session_state.get("stop_signal"):
-            return
-        symbol = msg['s']
-        if msg['k']['x']:  # kline closed
-            df = fetch_latest_data(symbol, client_global, interval='5m', limit=100)
-            df = apply_indicators(df, strategy_params[symbol])
-            df = generate_signals(df, strategy_params[symbol]['score_threshold'])
-            last = df.iloc[-1]
-            if symbol in signal_callbacks:
-                signal_callbacks[symbol](symbol, last)
+    async def socket_runner(socket):
+        async with socket as s:
+            while True:
+                msg = await s.recv()
+                if st.session_state.get("stop_signal"):
+                    continue
+                symbol = msg["s"]
+                if msg["k"]["x"]:
+                    df = fetch_latest_data(symbol, client_global, interval="5m", limit=100)
+                    df = apply_indicators(df, strategy_params[symbol])
+                    df = generate_signals(df, strategy_params[symbol]["score_threshold"])
+                    last = df.iloc[-1]
+                    if symbol in signal_callbacks:
+                        signal_callbacks[symbol](symbol, last)
 
     for sym in symbols:
-        ws_manager.start_kline_socket(callback=handle_kline, symbol=sym.lower(), interval='5m')
+        sock = ws_manager.kline_socket(symbol=sym.lower(), interval="5m")
+        _tasks[sym] = asyncio.create_task(socket_runner(sock))
 
 
 def stop_signal_stream() -> None:
     """Hentikan stream sinyal jika aktif."""
-    global ws_manager
-    if ws_manager:
-        try:
-            ws_manager.stop()
-        except Exception as e:
-            print(f"Stop signal stream error: {e}")
-        ws_manager = None
+    global ws_manager, _tasks
+    for task in _tasks.values():
+        task.cancel()
+    _tasks.clear()
+    ws_manager = None
+
+
+def is_signal_stream_running() -> bool:
+    """Periksa apakah signal stream sedang aktif."""
+    return bool(_tasks)
+
+

--- a/tests/test_ws_kline_mock.py
+++ b/tests/test_ws_kline_mock.py
@@ -1,0 +1,45 @@
+import asyncio
+
+import utils.bot_flags as bot_flags
+from execution import ws_signal_listener as wsl
+
+class DummySocket:
+    def __init__(self, messages):
+        self.messages = messages
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+    async def recv(self):
+        if self.messages:
+            return self.messages.pop(0)
+        await asyncio.sleep(0.01)
+        return {}
+
+class DummyBSM:
+    def __init__(self, messages):
+        self.messages = messages
+    def kline_socket(self, symbol, interval="5m"):
+        return DummySocket(self.messages)
+
+def test_signal_stream_callback(monkeypatch):
+    async def runner():
+        bot_flags.IS_READY = True
+        messages = [{"s": "BTCUSDT", "k": {"x": True}}]
+        dummy_bsm = DummyBSM(messages)
+        monkeypatch.setattr(wsl, "BinanceSocketManager", lambda **k: dummy_bsm)
+        monkeypatch.setattr(wsl, "fetch_latest_data", lambda *a, **k: __import__('pandas').DataFrame({'close':[1]}))
+        monkeypatch.setattr(wsl, "apply_indicators", lambda df, params: df)
+        monkeypatch.setattr(wsl, "generate_signals", lambda df, thr: df)
+
+        called = {}
+        wsl.register_signal_handler("BTCUSDT", lambda s, row: called.setdefault("s", s))
+
+        wsl.start_signal_stream("k", "s", None, ["BTCUSDT"], {"BTCUSDT": {"score_threshold": 0}})
+        await asyncio.sleep(0.05)
+        wsl.stop_signal_stream()
+        assert called.get("s") == "BTCUSDT"
+
+    asyncio.run(runner())
+
+


### PR DESCRIPTION
## Ringkasan
- refaktor ws_listener dan ws_signal_listener agar pakai `asyncio` dan `BinanceSocketManager`
- tambahkan pengecekan aktifnya websocket di trading_controller
- perbaikan fungsi `get_futures_balance` agar mendukung response list
- tambah unit test dummy untuk websocket

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888baa6ffe08328b2d6d837cc1beb9d