### PR TITLE
Perbaikan fitur bot dan penambahan unit test

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,6 +15,30 @@ setup_logger()
 load_dotenv()
 init_db()
 
+# === UTIL ===
+def build_cfg(api_key, api_secret, client, symbols, strategy_params, auto_sync,
+              leverage, risk_pct, max_pos, max_sym, max_slip, loss_limit,
+              notif_entry, notif_exit, notif_error, notif_resume, resume_flag):
+    return {
+        "api_key": api_key,
+        "api_secret": api_secret,
+        "client": client,
+        "symbols": list(symbols),
+        "strategy_params": strategy_params,
+        "auto_sync": auto_sync,
+        "leverage": int(leverage),
+        "risk_pct": float(risk_pct),
+        "max_pos": int(max_pos),
+        "max_sym": int(max_sym),
+        "max_slip": float(max_slip),
+        "loss_limit": float(loss_limit),
+        "notif_entry": notif_entry,
+        "notif_exit": notif_exit,
+        "notif_error": notif_error,
+        "notif_resume": notif_resume,
+        "resume_flag": resume_flag,
+    }
+
 # === STREAMLIT CONFIG ===
 st.set_page_config(page_title="RajaDollar Trading", layout="wide")
 st.title("🤖 RajaDollar Bot")
@@ -99,30 +123,31 @@ if start_clicked and not st.session_state.bot_running:
     if not api_key or not api_secret:
         st.error("❌ API key kosong.")
     else:
-        cfg = {
-            "api_key": api_key,
-            "api_secret": api_secret,
-            "client": client,
-            "symbols": multi_symbols,
-            "strategy_params": strategy_params,
-            "auto_sync": auto_sync,
-            "leverage": leverage,
-            "risk_pct": risk_pct / 100 if risk_pct > 1 else risk_pct,
-            "max_pos": max_pos,
-            "max_sym": max_sym,
-            "max_slip": max_slip,
-            "loss_limit": loss_limit,
-            "notif_entry": notif_entry,
-            "notif_exit": notif_exit,
-            "notif_error": notif_error,
-            "notif_resume": notif_resume,
-            "resume_flag": resume_flag,
-        }
+        cfg = build_cfg(
+            api_key,
+            api_secret,
+            client,
+            multi_symbols,
+            strategy_params,
+            auto_sync,
+            leverage,
+            risk_pct,
+            max_pos,
+            max_sym,
+            max_slip,
+            loss_limit,
+            notif_entry,
+            notif_exit,
+            notif_error,
+            notif_resume,
+            resume_flag,
+        )
         st.session_state.stop_signal = False
         st.session_state.handles = start_bot(cfg)
         if bot_flags.IS_READY:
             st.session_state.bot_running = True
             st.success("✅ Bot berjalan.")
+            st.info("Bot sedang menunggu sinyal...")
         else:
             st.error("❌ Gagal sync saldo Binance.")
 

--- a/notifications/command_handler.py
+++ b/notifications/command_handler.py
@@ -40,8 +40,10 @@ def send_document(chat_id, file_path):
 
 
 def handle_command(command_text, chat_id, bot_state):
+    """Proses perintah Telegram dengan validasi chat id."""
     logging.info(f"Telegram command from {chat_id}: {command_text}")
     if str(chat_id) not in AUTHORIZED_CHAT_IDS:
+        logging.warning(f"Unauthorized chat {chat_id}")
         send_reply(chat_id, "❌ Akses ditolak.")
         return
 

--- a/strategies/scalping_strategy.py
+++ b/strategies/scalping_strategy.py
@@ -92,21 +92,34 @@ def generate_signals(df, score_threshold=1.4):
     cond_long2 = (df['rsi'] > 40) & (df['rsi'] < 70)
     cond_long3 = df['ml_signal'] == 1
 
-    df['long_signal'] = (
-        cond_long1.astype(int) +
-        0.5 * cond_long2.astype(int) +
-        cond_long3.astype(int)
-    ) >= score_threshold
+    score_long = (
+        cond_long1.astype(float) +
+        0.5 * cond_long2.astype(float) +
+        cond_long3.astype(float)
+    )
+    df['score_long'] = score_long
+    df['long_signal'] = score_long >= score_threshold
 
     # Short signal conditions
     cond_short1 = (df['ema'] < df['sma']) & (df['macd'] < df['macd_signal'])
     cond_short2 = (df['rsi'] > 30) & (df['rsi'] < 60)
     cond_short3 = df['ml_signal'] == 0
 
-    df['short_signal'] = (
-        cond_short1.astype(int) +
-        0.5 * cond_short2.astype(int) +
-        cond_short3.astype(int)
-    ) >= score_threshold
+    score_short = (
+        cond_short1.astype(float) +
+        0.5 * cond_short2.astype(float) +
+        cond_short3.astype(float)
+    )
+    df['score_short'] = score_short
+    df['short_signal'] = score_short >= score_threshold
+
+    if not df['long_signal'].iloc[-1] and not df['short_signal'].iloc[-1]:
+        logging.info(
+            f"Skor long {score_long.iloc[-1]:.2f}, short {score_short.iloc[-1]:.2f} < {score_threshold}"
+        )
+    else:
+        logging.info(
+            f"Skor long {score_long.iloc[-1]:.2f}, short {score_short.iloc[-1]:.2f}"
+        )
 
     return df

--- a/tests/test_main_cfg.py
+++ b/tests/test_main_cfg.py
@@ -1,0 +1,7 @@
+from main import build_cfg
+
+def test_build_cfg():
+    cfg = build_cfg('k','s','client',['BTC'],{'BTC':{}},True,10,0.02,1,1,0.5,-50,True,True,True,True,False)
+    assert cfg['risk_pct'] == 0.02
+    assert cfg['leverage'] == 10
+    assert cfg['symbols'] == ['BTC']

--- a/tests/test_resume_helper.py
+++ b/tests/test_resume_helper.py
@@ -1,0 +1,19 @@
+from utils.resume_helper import sync_with_binance
+from unittest.mock import patch
+
+class DummyClient:
+    def futures_position_information(self):
+        return []
+
+
+def test_sync_ignore_orphan(monkeypatch):
+    monkeypatch.setattr('utils.resume_helper.load_state', lambda: [{"symbol":"BTCUSDT","side":"long"}])
+    saved = []
+    monkeypatch.setattr('utils.resume_helper.save_state', lambda x: saved.extend(x))
+    notes = []
+    monkeypatch.setattr('utils.resume_helper.kirim_notifikasi_telegram', lambda m: notes.append(m))
+
+    result = sync_with_binance(DummyClient())
+    assert result == []
+    assert saved == []
+    assert any("Orphan" in n for n in notes)

--- a/tests/test_scalping_strategy.py
+++ b/tests/test_scalping_strategy.py
@@ -38,5 +38,15 @@ def test_generate_signals(dummy_df, config):
     df = generate_signals(df, config['score_threshold'])
     assert 'long_signal' in df.columns
     assert 'short_signal' in df.columns
-    assert df['long_signal'].iloc[-1] in [True, False]
-    assert df['short_signal'].iloc[-1] in [True, False]
+    assert 'score_long' in df.columns
+    assert 'score_short' in df.columns
+    assert df['long_signal'].iloc[-1] == (df['score_long'].iloc[-1] >= config['score_threshold'])
+    assert df['short_signal'].iloc[-1] == (df['score_short'].iloc[-1] >= config['score_threshold'])
+
+
+def test_no_entry_logs(dummy_df, config, caplog):
+    config['score_threshold'] = 2.0
+    df = apply_indicators(dummy_df.copy(), config)
+    with caplog.at_level('INFO'):
+        df = generate_signals(df, config['score_threshold'])
+    assert any('Skor long' in r.message for r in caplog.records)

--- a/tests/utils/test_resume_helper.py
+++ b/tests/utils/test_resume_helper.py
@@ -11,10 +11,13 @@ def test_handle_resume_with_active(monkeypatch):
     def send(msg):
         sent["msg"] = msg
     monkeypatch.setattr("utils.resume_helper.kirim_notifikasi_telegram", send)
+    from unittest.mock import mock_open
+    m = mock_open(read_data="{\"BTC\": {}}")
+    monkeypatch.setattr("builtins.open", m)
+    monkeypatch.setattr("json.load", lambda f: {"BTC": {}})
 
     active = handle_resume(True, True)
     assert len(active) == 1
-    # Update expected message sesuai implementasi
     assert "🔄 Resumed" in sent["msg"] and "BTC long" in sent["msg"]
 
 
@@ -60,10 +63,8 @@ def test_sync_with_binance_warn(monkeypatch, capsys):
     
     # Execute
     result = sync_with_binance(client)
-    
-    # Verify
-    assert len(result) == 2  # Should contain both positions
-    assert any(t["symbol"] == "BTCUSDT" for t in result)
-    assert any(t["symbol"] == "ETHUSDT" for t in result)
-    assert "BTCUSDT" in notifications[0]  # Verify notification
+
+    assert len(result) == 1
+    assert result[0]["symbol"] == "BTCUSDT"
+    assert "Added" in notifications[0]
 


### PR DESCRIPTION
## Ringkasan
- validasi chat id pada command Telegram
- sinkronisasi posisi abaikan simbol yang tidak ada di konfigurasi
- log skor sinyal pada strategi scalping
- notifikasi idle pada ws listener dan gunakan `stop_signal`
- perbaiki pembuatan cfg di UI dan tampilkan info menunggu sinyal
- fungsi resume hanya melanjutkan posisi yang cocok
- tambah beberapa unit test baru

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aea23aab08328863d26c0e4f6dd56