### PR TITLE
Perbaikan command Telegram dan sinkronisasi RajaDollar

### DIFF
--- a/execution/signal_entry.py
+++ b/execution/signal_entry.py
@@ -78,19 +78,24 @@ def on_signal(
         for side in ['long', 'short']:
             signal_flag = row.get('long_signal' if side == 'long' else 'short_signal', False)
             if not signal_flag:
+                logging.info(f"Skipped {symbol} - signal_flag False for {side}")
                 continue
 
             if not can_open_new_position(symbol, max_pos, max_sym, open_pos):
+                logging.info(f"Skipped {symbol} - max position reached")
                 continue
 
             if is_position_open(active, symbol, side):
+                logging.info(f"Skipped {symbol} - position already open")
                 continue
 
             if is_liquidation_risk(price, side, leverage):
+                logging.info(f"Skipped {symbol} - liquidation risk")
                 continue
 
             order_side = "BUY" if side == 'long' else "SELL"
             if not verify_price_before_order(client, symbol, order_side, price, max_slip / 100):
+                logging.info(f"Skipped {symbol} - price slippage")
                 continue
 
             # Calculate position size

--- a/execution/ws_signal_listener.py
+++ b/execution/ws_signal_listener.py
@@ -2,6 +2,7 @@ import asyncio
 import nest_asyncio
 from binance import AsyncClient, BinanceSocketManager
 import streamlit as st
+import logging
 from utils.data_provider import fetch_latest_data
 from strategies.scalping_strategy import apply_indicators, generate_signals
 import utils.bot_flags as bot_flags
@@ -36,6 +37,7 @@ async def _socket_runner(symbol: str, strategy_params: dict):
     socket = ws_manager.kline_socket(symbol=symbol.lower(), interval="5m")
     async with socket as s:
         idle_notified = False
+        logging.info(f"\ud83d\udcf1 {symbol} Loop aktif - menunggu sinyal....")
         while True:
             try:
                 msg = await s.recv()
@@ -49,6 +51,7 @@ async def _socket_runner(symbol: str, strategy_params: dict):
                     if symbol in signal_callbacks:
                         signal_callbacks[symbol](symbol, last)
                     if not last.get("long_signal") and not last.get("short_signal"):
+                        logging.info(f"Skipped {symbol} - {last.get('skip_reason', 'wait')}")
                         if not idle_notified:
                             kirim_notifikasi_telegram(f"Menunggu sinyal {symbol}...")
                             idle_notified = True

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import os, json, timeit, asyncio
 import nest_asyncio
+import logging
 
 from dotenv import load_dotenv
 from utils.logger import setup_logger
@@ -143,11 +144,14 @@ if start_clicked and not st.session_state.bot_running:
             resume_flag,
         )
         st.session_state.stop_signal = False
+        logging.info(
+            f"Start bot with max_pos={max_pos}, max_sym={max_sym}, risk_pct={risk_pct}"
+        )
         st.session_state.handles = start_bot(cfg)
         if bot_flags.IS_READY:
             st.session_state.bot_running = True
             st.success("✅ Bot berjalan.")
-            st.info("Bot sedang menunggu sinyal...")
+            st.info("Bot aktif & menunggu sinyal")
         else:
             st.error("❌ Gagal sync saldo Binance.")
 

--- a/strategies/scalping_strategy.py
+++ b/strategies/scalping_strategy.py
@@ -113,7 +113,12 @@ def generate_signals(df, score_threshold=1.4):
     df['score_short'] = score_short
     df['short_signal'] = score_short >= score_threshold
 
+    reason = ""
     if not df['long_signal'].iloc[-1] and not df['short_signal'].iloc[-1]:
+        if not cond_long1.iloc[-1] and not cond_short1.iloc[-1]:
+            reason = "MA not aligned"
+        else:
+            reason = "Score below threshold"
         logging.info(
             f"Skor long {score_long.iloc[-1]:.2f}, short {score_short.iloc[-1]:.2f} < {score_threshold}"
         )
@@ -122,4 +127,5 @@ def generate_signals(df, score_threshold=1.4):
             f"Skor long {score_long.iloc[-1]:.2f}, short {score_short.iloc[-1]:.2f}"
         )
 
+    df.loc[df.index[-1], 'skip_reason'] = reason
     return df

--- a/tests/notifications/test_command_handler.py
+++ b/tests/notifications/test_command_handler.py
@@ -20,13 +20,18 @@ def base_env():
 def test_status_command():
     with patch.dict(os.environ, base_env()):
         ch = reload_module()
+        df = pd.DataFrame({
+            "symbol": ["BTC"],
+            "side": ["long"],
+            "pnl": [1.0]
+        })
         with patch("notifications.command_handler.requests.post") as mock_post, \
-             patch.object(ch, "get_all_trades", return_value=pd.DataFrame()):
-            bot_state = {"positions": []}
+             patch.object(ch, "get_all_trades", return_value=df):
+            bot_state = {"positions": ["BTC"]}
             ch.handle_command("/status", "chat", bot_state)
             assert mock_post.call_count == 1
             data = mock_post.call_args.kwargs["data"]
-            assert "Bot Aktif" in data["text"]
+            assert "Equity" in data["text"] and "1" in data["text"]
 
 
 def test_entry_command():
@@ -35,7 +40,7 @@ def test_entry_command():
         with patch("notifications.command_handler.requests.post") as mock_post:
             bot_state = {}
             ch.handle_command("/entry BTC", "chat", bot_state)
-            assert bot_state["manual_entry"] == "BTC"
+            assert bot_state["manual_entry_flag"]["BTC"] is True
             data = mock_post.call_args.kwargs["data"]
             assert "ENTRY" in data["text"]
 

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -17,12 +17,25 @@ def env():
 def test_authorized_status_command():
     with patch.dict(os.environ, env()):
         ch = reload_module()
+        df = pd.DataFrame({
+            "symbol": ["BTC"],
+            "side": ["long"],
+            "pnl": [2.0]
+        })
         with patch("notifications.command_handler.requests.post") as mock_post, \
-             patch.object(ch, "get_all_trades", return_value=pd.DataFrame()):
-            bot_state = {"positions": []}
+             patch.object(ch, "get_all_trades", return_value=df):
+            bot_state = {"positions": ["BTC"]}
             ch.handle_command("/status", "chat", bot_state)
             data = mock_post.call_args.kwargs["data"]
-            assert "Bot Aktif" in data["text"]
+            assert "Equity" in data["text"] and "2" in data["text"]
+
+def test_entry_command_flag():
+    with patch.dict(os.environ, env()):
+        ch = reload_module()
+        with patch("notifications.command_handler.requests.post") as mock_post:
+            bot_state = {}
+            ch.handle_command("/entry BTCUSDT", "chat", bot_state)
+            assert bot_state["manual_entry_flag"]["BTCUSDT"] is True
 
 
 def test_unauthorized_command():

--- a/tests/test_telegram_extra.py
+++ b/tests/test_telegram_extra.py
@@ -1,0 +1,39 @@
+import importlib
+import os
+from unittest.mock import patch
+import pandas as pd
+
+
+def reload_module():
+    import notifications.command_handler as ch
+    importlib.reload(ch)
+    return ch
+
+
+def env():
+    return {"TELEGRAM_TOKEN": "token", "TELEGRAM_CHAT_ID": "chat"}
+
+
+def test_status_equity_and_position(monkeypatch):
+    with patch.dict(os.environ, env()):
+        ch = reload_module()
+        df = pd.DataFrame({
+            "symbol": ["BTC"],
+            "side": ["long"],
+            "pnl": [3.0]
+        })
+        with patch("notifications.command_handler.requests.post") as mock_post:
+            monkeypatch.setattr(ch, "get_all_trades", lambda: df)
+            bot_state = {"positions": ["BTC"]}
+            ch.handle_command("/status", "chat", bot_state)
+            text = mock_post.call_args.kwargs["data"]["text"]
+            assert "Equity" in text and "3.0" in text
+
+
+def test_entry_sets_flag(monkeypatch):
+    with patch.dict(os.environ, env()):
+        ch = reload_module()
+        with patch("notifications.command_handler.requests.post"):
+            bot_state = {}
+            ch.handle_command("/entry BTCUSDT", "chat", bot_state)
+            assert bot_state["manual_entry_flag"]["BTCUSDT"] is True


### PR DESCRIPTION
## Summary
- tambahkan flag manual_entry_flag pada command handler
- jalankan polling Telegram via ApplicationBuilder
- logging loop aktif dan alasan skip sinyal
- perbaiki deteksi orphan pada resume helper
- tampilkan log konfigurasi start bot
- tambah test telegram baru dan sesuaikan test lama

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b18e2d1cc83288fcc09a16acd82e2