### PR TITLE
Perbaikan training ML per simbol

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -117,7 +117,7 @@ real_api_key=xxx
 real_api_secret=xxx
 ```
 
-Strategi dikonfigurasi lewat `config/strategy_params.json`. Model ML akan dilatih otomatis, bisa juga manual dengan `python ml/training.py` atau via Telegram (`/ml`, `/mltrain`).
+Strategi dikonfigurasi lewat `config/strategy_params.json`. Model ML akan dilatih otomatis. Untuk manual gunakan `python ml/training.py --symbol BTCUSDT` atau `--symbol all` juga bisa lewat Telegram (`/ml`, `/mltrain`).
 
 ### FAQ
 - **Apakah aman restart?** Ya, data di `runtime_state` dipulihkan otomatis.
@@ -156,7 +156,7 @@ Setelah itu bot dapat diakses di `http://bot.appshin.xyz`.
 ### Catatan tambahan
 - Perintah Telegram: `/status`, `/entry`, `/stop`, `/ml`, `/mltrain`, `/log`, `/chart`.
 - Strategi diatur lewat `config/strategy_params.json`.
-- Model ML bisa dilatih ulang dengan `python ml/training.py` atau via Telegram `/mltrain`.
+- Model ML bisa dilatih ulang dengan `python ml/training.py --symbol SYMBOL` atau via Telegram `/mltrain`.
 
 ## 👨‍💻 Pengembang & Dukungan
 Bot ini didukung dan didokumentasikan oleh [Shingiwoo].

--- a/ml/training.py
+++ b/ml/training.py
@@ -1,71 +1,132 @@
+import os
+import json
+import pickle
+import datetime
+import argparse
+from typing import List
+
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
-import pickle
-import os
 import schedule
-import time
 import threading
-import json
-import pandas as pd
-import os, json
-import datetime
+import time
+
 from notifications.notifier import kirim_notifikasi_ml_training
 from utils.logger import LOG_DIR
 
-def train_model():
-    df = pd.read_csv("data/training_data.csv")  # sesuaikan dengan pathmu
-    feature_cols = ["ema", "sma", "macd", "rsi"]  # sesuaikan
-    X = df[feature_cols]
+DATA_DIR = "data/training_data"
+MODEL_DIR = "models"
+FEATURE_COLS = ["ema", "sma", "macd", "rsi"]
+MIN_DATA = 100
+MIN_ACCURACY = 0.6
+
+
+def _load_dataset(symbol: str) -> pd.DataFrame | None:
+    path = os.path.join(DATA_DIR, f"{symbol}.csv")
+    if not os.path.exists(path):
+        print(f"[ML] Data {path} tidak ditemukan")
+        return None
+    df = pd.read_csv(path)
+    df = df.dropna(subset=FEATURE_COLS + ["label"])
+    return df
+
+
+def train_model(symbol: str) -> float:
+    """Latih model untuk satu simbol dan kembalikan akurasinya."""
+    df = _load_dataset(symbol)
+    if df is None:
+        return 0.0
+
+    valid = len(df)
+    if valid < MIN_DATA:
+        msg = f"⚠️ Data {symbol} kurang dari {MIN_DATA} baris, dilewati."
+        print(f"[ML] {msg}")
+        kirim_notifikasi_ml_training(msg)
+        return 0.0
+
+    X = df[FEATURE_COLS]
     y = df["label"]
+    X_tr, X_te, y_tr, y_te = train_test_split(X, y, test_size=0.2, random_state=42)
+    model = RandomForestClassifier(n_estimators=100, random_state=42)
+    model.fit(X_tr, y_tr)
 
-    # Split dataset
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    preds = model.predict(X_te)
+    acc = accuracy_score(y_te, preds)
 
-    # Train model
-    model = RandomForestClassifier(n_estimators=100)
-    model.fit(X_train, y_train)
-
-    # Eval
-    acc = model.score(X_test, y_test)
     now = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M:%S")
-    msg = f"✅ *ML Training Selesai*\n• Akurasi: `{acc:.2%}`\n• Data: `{len(X)}` baris\n• Jam: `{now}`"
+    msg = (
+        f"✅ *ML Training Selesai* {symbol}\n"
+        f"• Akurasi: `{acc:.2%}`\n"
+        f"• Data valid: `{valid}` baris\n"
+        f"• Jam: `{now}`"
+    )
     kirim_notifikasi_ml_training(msg)
 
-    os.makedirs("models", exist_ok=True)
-    with open("models/model_scalping.pkl", "wb") as f:
-        pickle.dump(model, f)
+    if acc >= MIN_ACCURACY:
+        os.makedirs(MODEL_DIR, exist_ok=True)
+        with open(os.path.join(MODEL_DIR, f"{symbol}_scalping.pkl"), "wb") as f:
+            pickle.dump(model, f)
+    else:
+        print(
+            f"[ML] Akurasi {acc:.2%} di bawah ambang {MIN_ACCURACY:.0%}, model tidak disimpan"
+        )
 
-    # Simpan log
     os.makedirs(LOG_DIR, exist_ok=True)
-    log_path = os.path.join(LOG_DIR, f"ml_training_{datetime.datetime.now(datetime.UTC).strftime('%Y%m%d_%H%M%S')}.txt")
+    log_path = os.path.join(
+        LOG_DIR,
+        f"ml_training_{symbol}_{datetime.datetime.now(datetime.UTC).strftime('%Y%m%d_%H%M%S')}.txt",
+    )
     with open(log_path, "w") as f:
-        log_data = {
-            "timestamp": now,
-            "accuracy": acc,
-            "train_size": len(X_train),
-            "test_size": len(X_test)
-        }
-        json.dump(log_data, f, indent=2)
+        json.dump({"timestamp": now, "accuracy": acc, "data": valid}, f, indent=2)
 
-def run_training_scheduler():
+    print(f"[ML] {symbol} selesai dengan akurasi {acc:.2%}")
+    return acc
+
+
+def train_all(symbols: List[str] | None = None) -> None:
+    if symbols is None:
+        if not os.path.isdir(DATA_DIR):
+            print(f"[ML] Folder {DATA_DIR} tidak ada")
+            return
+        files = [f for f in os.listdir(DATA_DIR) if f.endswith(".csv")]
+        symbols = [os.path.splitext(f)[0] for f in files]
+    for sym in symbols:
+        train_model(sym)
+
+
+def run_training_scheduler(symbols: List[str] | None = None) -> None:
     def train_job():
         print("[SCHEDULE] Melatih model otomatis...")
-        dummy_data = pd.DataFrame({
-            'close': [100 + i + (i%5) for i in range(200)],
-            'rsi': [50 + (i%10) for i in range(200)],
-            'macd': [0.1 * (i % 5) for i in range(200)],
-            'atr': [1.5 for _ in range(200)],
-            'bb_width': [0.02 for _ in range(200)]
-        })
-        train_model(dummy_data) # type: ignore
+        train_all(symbols)
         print("[SCHEDULE] ✅ Model berhasil diperbarui (mingguan)")
 
     schedule.every().monday.at("06:00").do(train_job)
+
     def loop():
         while True:
             schedule.run_pending()
             time.sleep(60)
 
     threading.Thread(target=loop, daemon=True).start()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Training model ML per simbol")
+    parser.add_argument(
+        "--symbol",
+        "-s",
+        default="all",
+        help="Simbol untuk dilatih, gunakan 'all' untuk semua",
+    )
+    args = parser.parse_args()
+
+    if args.symbol.lower() == "all":
+        train_all()
+    else:
+        train_model(args.symbol.upper())
+
+
+if __name__ == "__main__":
+    main()

--- a/notifications/command_handler.py
+++ b/notifications/command_handler.py
@@ -7,7 +7,6 @@ from ml.training import train_model
 import matplotlib.pyplot as plt
 from database.sqlite_logger import get_all_trades, export_trades_csv
 from notifications.notifier import kirim_notifikasi_telegram
-from ml.training import train_model
 from telegram.ext import ApplicationBuilder, MessageHandler, filters
 
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
@@ -99,7 +98,7 @@ def handle_command(command_text, chat_id, bot_state):
     
     elif command_text.lower() == "/mltrain":
         try:
-            train_model()
+            train_model("all")
             latest_log = sorted(glob.glob(os.path.join(LOG_DIR, "ml_training_*.txt")))[-1]
             with open(latest_log, "r") as f:
                 content = f.read()
@@ -141,7 +140,7 @@ def handle_command(command_text, chat_id, bot_state):
         if len(df) < 10:
             send_reply(chat_id, "📉 Tidak cukup data untuk training.")
         else:
-            train_model()
+            train_model("all")
             send_reply(chat_id, "✅ *Model berhasil dilatih ulang!*")
 
     elif command_text == "/chart":


### PR DESCRIPTION
## Ringkasan
- refactor `ml/training.py` supaya bisa melatih model per simbol dan menyimpan model per file
- perintah Telegram yang memanggil training ikut diperbarui
- dokumentasi CLI di README disesuaikan

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c9a1a468883289a716fa057755aa8