### PR TITLE
Implement per-symbol ML models

### DIFF
--- a/ml/historical_trainer.py
+++ b/ml/historical_trainer.py
@@ -1,0 +1,42 @@
+import os
+import logging
+import pickle
+import pandas as pd
+from ta.trend import EMAIndicator, SMAIndicator, MACD
+from ta.momentum import RSIIndicator
+from sklearn.ensemble import RandomForestClassifier
+
+
+def _apply_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    close = pd.to_numeric(df["close"], errors="coerce")
+    df["ema"] = EMAIndicator(close, window=14).ema_indicator()
+    df["sma"] = SMAIndicator(close, window=14).sma_indicator()
+    macd = MACD(close)
+    df["macd"] = macd.macd()
+    df["rsi"] = RSIIndicator(close, window=14).rsi()
+    return df
+
+
+def train_from_history(symbol: str) -> None:
+    """Latih model sederhana dari data historis untuk simbol."""
+    path = f"data/historical_data/1h/{symbol.upper()}_1h.csv"
+    if not os.path.exists(path):
+        logging.error(f"Historical data {path} tidak ditemukan")
+        return
+    df = pd.read_csv(path)
+    df.columns = [c.lower() for c in df.columns]
+    df = _apply_indicators(df)
+    df["label"] = (df["close"].shift(-1) > df["close"]).astype(int)
+    df = df.dropna(subset=["ema", "sma", "macd", "rsi", "label"])
+    if len(df) < 50:
+        logging.warning(f"Data {symbol} terlalu sedikit untuk training")
+        return
+    X = df[["ema", "sma", "macd", "rsi"]]
+    y = df["label"]
+    model = RandomForestClassifier(n_estimators=100, random_state=42)
+    model.fit(X, y)
+    os.makedirs("models", exist_ok=True)
+    with open(f"models/{symbol.upper()}_scalping.pkl", "wb") as f:
+        pickle.dump(model, f)
+    logging.info(f"Model {symbol} berhasil dibuat dari data historis")

--- a/tests/strategies/test_ml_prediction.py
+++ b/tests/strategies/test_ml_prediction.py
@@ -12,8 +12,8 @@ def test_ml_prediction(tmp_path, monkeypatch):
         pickle.dump(DummyModel(), f)
 
     monkeypatch.setattr(strat, 'MODEL_PATH', str(model_path))
-    strat._ml_model = None
-    strat.load_ml_model()
+    strat._ml_models = {}
+    strat.load_ml_model("")
 
     length = 20
     df = pd.DataFrame({
@@ -26,7 +26,7 @@ def test_ml_prediction(tmp_path, monkeypatch):
 
     config = {'ema_period':2,'sma_period':2,'rsi_period':2,'macd_fast':1,'macd_slow':3,'macd_signal':1}
     df = strat.apply_indicators(df, config)
-    df = strat.generate_signals(df, 1.0)
+    df = strat.generate_signals(df, 1.0, "")
     assert 'ml_signal' in df.columns
     assert df['ml_signal'].iloc[-1] == 0
     assert 'short_signal' in df.columns


### PR DESCRIPTION
## Summary
- load ML models per-symbol and auto-train from historical data
- add ML fallback training logic
- update scalping strategy for symbol-specific model prediction
- create minimal historical trainer
- adjust ML prediction tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c9d825afc8328b9e5608d530bb260