### PR TITLE
Perkuat penulisan file dengan Pathlib dan cek izin

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -100,6 +100,37 @@ Keterangan:
 - `--cpus` dan `--memory` membatasi resource container.
 - `-p 8588:8588` membuka port Streamlit.
 - `-v` membuat direktori `runtime_state` persisten agar aman saat restart.
+## 🛠️ Deployment Notes
+
+Sebelum menjalankan bot di Docker, siapkan direktori berikut di host:
+
+- `./data/training_data/`
+- `./models/`
+- `./logs/`
+- `./runtime_state/`
+
+Ketika menjalankan container, pasang volume supaya folder tersebut tersimpan di host:
+
+```
+-v $PWD/data:/app/data \
+-v $PWD/models:/app/models \
+-v $PWD/logs:/app/logs \
+-v $PWD/runtime_state:/app/runtime_state
+```
+
+Contoh perintah lengkap:
+
+```bash
+sudo docker run -d \
+  --name rajadollar_bot \
+  --env-file .env \
+  -v $PWD/data:/app/data \
+  -v $PWD/models:/app/models \
+  -v $PWD/logs:/app/logs \
+  -v $PWD/runtime_state:/app/runtime_state \
+  -p 8588:8588 \
+  rajadollar:latest
+```
 
 ### Reverse Proxy Nginx
 1. Install nginx: `sudo apt install nginx`

--- a/tests/notifications/test_error_logger.py
+++ b/tests/notifications/test_error_logger.py
@@ -10,7 +10,7 @@ def test_laporkan_error():
         with patch("notifications.notifier.open", m), \
              patch("notifications.notifier.requests.post") as mock_post:
             notifier.laporkan_error("kesalahan fatal")
-            m.assert_called_once_with("/app/logs/error.log", "a")
+            m.assert_called_once_with(os.path.join("logs", "error.log"), "a")
             handle = m()
             assert "kesalahan fatal" in handle.write.call_args[0][0]
             mock_post.assert_called_once()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,13 +1,19 @@
 import logging
 import os
+from pathlib import Path
 
-LOG_DIR = os.getenv("LOG_DIR", "/app/logs")
+LOG_DIR = os.getenv("LOG_DIR", "logs")
+
 
 def setup_logger():
-    os.makedirs(LOG_DIR, exist_ok=True)
+    log_dir = Path(LOG_DIR)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    if not os.access(log_dir, os.W_OK):
+        print(f"[LOGGER] Folder {log_dir} tidak bisa ditulis")
+        return
     logging.basicConfig(
-        filename=os.path.join(LOG_DIR, "app.log"),
+        filename=str(log_dir / "app.log"),
         format="%(asctime)s [%(levelname)s] %(message)s",
-        level=logging.INFO
+        level=logging.INFO,
     )
     


### PR DESCRIPTION
## Ringkasan
- Gunakan `pathlib.Path` dan validasi direktori di modul training, historical_trainer, dan logger.
- Tambah peringatan bila folder tidak dapat ditulis serta menyesuaikan path log.
- Perbarui README dengan catatan deployment dan contoh penggunaan volume Docker.

## Pengujian
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688d7a693fd48328affa2a5b8c6e3896