### PR TITLE
Tambah engine backtest modular

### DIFF
--- a/backtesting/backtest_engine.py
+++ b/backtesting/backtest_engine.py
@@ -1,30 +1,71 @@
+import pandas as pd
+
 from strategies.scalping_strategy import apply_indicators, generate_signals
 from risk_management.position_manager import apply_trailing_sl
 from execution.order_monitor import check_exit_condition
 from models.trade import Trade
-import pandas as pd
 
-def run_backtest(df, initial_capital=1000, score_threshold=1.4, direction='long'):
+
+def run_backtest(
+    df: pd.DataFrame,
+    initial_capital: float = 1000,
+    score_threshold: float = 1.4,
+    symbol: str = "",
+    direction: str = "both",
+    start: str | None = None,
+    end: str | None = None,
+):
+    """Jalankan backtest bar-per-bar secara modular.
+
+    Parameter start dan end dapat berupa string waktu yang dapat
+    diubah ke pandas.Timestamp.
+    """
+
+    df = df.sort_index()
+    if start:
+        df = df[df.index >= pd.to_datetime(start)]
+    if end:
+        df = df[df.index <= pd.to_datetime(end)]
+
     df = apply_indicators(df)
-    df = generate_signals(df, score_threshold)
 
     capital = initial_capital
-    trades = []
-    active_trade = None
+    trades: list[Trade] = []
+    active_trade: Trade | None = None
+    equity: list[float] = []
     hold = 0
 
-    for i in range(1, len(df)):
-        row = df.iloc[i]
-        price = row['close']
-        time = df.index[i].isoformat()
+    for i in range(len(df)):
+        df_slice = df.iloc[: i + 1].copy()
+        df_slice = generate_signals(df_slice, score_threshold, symbol)
+        row = df_slice.iloc[-1]
+        price = row["close"]
+        time = df_slice.index[-1].isoformat()
 
         if active_trade:
             hold += 1
-            active_trade.trailing_sl = apply_trailing_sl(price, active_trade.entry_price, direction, active_trade.trailing_sl, 0.5, 0.25)
+            active_trade.trailing_sl = apply_trailing_sl(
+                price,
+                active_trade.entry_price,
+                active_trade.side,
+                active_trade.trailing_sl,
+                0.5,
+                0.25,
+            )
 
-            if check_exit_condition(price, active_trade.trailing_sl, active_trade.tp, hold, 100, direction):
+            if check_exit_condition(
+                price,
+                active_trade.trailing_sl,
+                active_trade.tp,
+                hold,
+                100,
+                active_trade.side,
+            ):
                 exit_price = price
-                pnl = (exit_price - active_trade.entry_price) * active_trade.size if direction == 'long' else (active_trade.entry_price - exit_price) * active_trade.size
+                if active_trade.side == "long":
+                    pnl = (exit_price - active_trade.entry_price) * active_trade.size
+                else:
+                    pnl = (active_trade.entry_price - exit_price) * active_trade.size
                 capital += pnl
                 active_trade.exit_price = exit_price
                 active_trade.exit_time = time
@@ -33,16 +74,22 @@ def run_backtest(df, initial_capital=1000, score_threshold=1.4, direction='long'
                 active_trade = None
                 hold = 0
 
-        elif direction == 'long' and row['long_signal']:
-            size = capital * 0.05 / row['close']
-            sl = row['close'] - 0.01 * row['close']
-            tp = row['close'] + 0.02 * row['close']
-            active_trade = Trade(row.name, 'long', time, row['close'], size, sl, tp, trailing_sl=sl)
+        if not active_trade:
+            allow_long = direction in ("long", "both")
+            allow_short = direction in ("short", "both")
+            if allow_long and row.get("long_signal"):
+                size = capital * 0.05 / price
+                sl = price * (1 - 0.01)
+                tp = price * (1 + 0.02)
+                active_trade = Trade(symbol, "long", time, price, size, sl, tp, trailing_sl=sl)
+            elif allow_short and row.get("short_signal"):
+                size = capital * 0.05 / price
+                sl = price * (1 + 0.01)
+                tp = price * (1 - 0.02)
+                active_trade = Trade(symbol, "short", time, price, size, sl, tp, trailing_sl=sl)
 
-        elif direction == 'short' and row['short_signal']:
-            size = capital * 0.05 / row['close']
-            sl = row['close'] + 0.01 * row['close']
-            tp = row['close'] - 0.02 * row['close']
-            active_trade = Trade(row.name, 'short', time, row['close'], size, sl, tp, trailing_sl=sl)
+        equity.append(capital)
 
-    return trades, capital
+    equity_df = pd.DataFrame({"equity": equity}, index=df.index[: len(equity)])
+    return trades, equity_df, capital
+

--- a/backtesting/data_loader.py
+++ b/backtesting/data_loader.py
@@ -1,8 +1,16 @@
 import pandas as pd
 
-def load_csv(filepath):
+
+def load_csv(filepath: str, start: str | None = None, end: str | None = None) -> pd.DataFrame:
+    """Muat data CSV dan filter sesuai rentang waktu."""
+
     df = pd.read_csv(filepath)
     df.columns = [col.lower() for col in df.columns]
-    df['timestamp'] = pd.to_datetime(df['timestamp'])
-    df.set_index('timestamp', inplace=True)
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    df.sort_values("timestamp", inplace=True)
+    if start:
+        df = df[df["timestamp"] >= pd.to_datetime(start)]
+    if end:
+        df = df[df["timestamp"] <= pd.to_datetime(end)]
+    df.set_index("timestamp", inplace=True)
     return df

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -1,12 +1,14 @@
 from backtesting.backtest_engine import run_backtest
 from backtesting.data_loader import load_csv
 
+
 def test_run_backtest():
-    # File CSV harus ada di data/historical_data//1h/BTCUSDT_1h.csv
     df = load_csv("data/historical_data/1h/BTCUSDT_1h.csv")
-    trades, capital = run_backtest(df)
+    trades, equity, final_capital = run_backtest(df, symbol="BTCUSDT")
     assert isinstance(trades, list)
-    print(f"Backtest {len(trades)} trades, capital: {capital}")
+    assert not equity.empty
+    print(f"Backtest {len(trades)} trades, modal akhir: {final_capital}")
+
 
 if __name__ == "__main__":
     test_run_backtest()


### PR DESCRIPTION
## Ringkasan
- bangun engine backtest bar-per-bar dengan pengelolaan posisi dan pencatatan equity curve
- lengkapi loader CSV dengan sortir dan filter waktu
- perbarui tes untuk memeriksa keluaran baru

## Pengujian
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688db84dac508328b09ba43164c0c74d