### PR TITLE
tambah perhitungan metrik backtest

### DIFF
--- a/backtesting/metrics.py
+++ b/backtesting/metrics.py
@@ -1,15 +1,78 @@
+"""Perhitungan metrik kinerja hasil backtest."""
+
+from __future__ import annotations
+
+import numpy as np
 import pandas as pd
 
-def calculate_metrics(trades):
+
+def calculate_metrics(
+    trades: list,
+    equity_curve: pd.DataFrame | pd.Series | None = None,
+):
+    """Hitung berbagai metrik kinerja.
+
+    Parameter
+    ---------
+    trades:
+        Daftar objek *Trade* yang sudah selesai.
+    equity_curve:
+        Deret saldo ekuitas dari waktu ke waktu. Opsional.
+
+    Returns
+    -------
+    dict | tuple(dict, pd.DataFrame)
+        Jika *equity_curve* diberikan, fungsi juga mengembalikan
+        DataFrame berisi kurva ekuitas beserta drawdown-nya.
+    """
+
     if not trades:
-        return {}
+        return ({}, None) if equity_curve is not None else {}
+
     df = pd.DataFrame([t.to_dict() for t in trades])
-    wins = df[df['pnl'] > 0]
-    losses = df[df['pnl'] <= 0]
-    return {
-        "Total Trades": len(df),
-        "Win Rate": f"{(len(wins) / len(df) * 100):.2f}%",
-        "Total PnL": f"{df['pnl'].sum():.2f}",
-        "Profit Factor": f"{wins['pnl'].sum() / abs(losses['pnl'].sum()) if not losses.empty else '∞'}",
-        "Avg PnL": f"{df['pnl'].mean():.2f}"
+
+    # ---------------- Metrik dasar ----------------
+    total = len(df)
+    menang = df[df["pnl"] > 0]
+    kalah = df[df["pnl"] <= 0]
+
+    metrik: dict[str, object] = {
+        "Total Transaksi": int(total),
+        "Persentase Menang": len(menang) / total * 100,
+        "Total PnL": df["pnl"].sum(),
+        "Rata-rata PnL": df["pnl"].mean(),
+        "Rata-rata Profit": menang["pnl"].mean() if not menang.empty else 0.0,
+        "Rata-rata Rugi": kalah["pnl"].mean() if not kalah.empty else 0.0,
     }
+
+    # --------------- Waktu tahan rata-rata ---------------
+    if "exit_time" in df.columns and df["exit_time"].notna().any():
+        masuk = pd.to_datetime(df["entry_time"])
+        keluar = pd.to_datetime(df["exit_time"])
+        durasi = (keluar - masuk).dropna()
+        if not durasi.empty:
+            metrik["Rata-rata Waktu Tahan"] = durasi.mean()
+
+    # --------------- Rasio Sharpe & Drawdown ---------------
+    if equity_curve is not None and not equity_curve.empty:
+        eq = (
+            equity_curve["equity"]
+            if isinstance(equity_curve, pd.DataFrame)
+            else equity_curve
+        )
+
+        ret = eq.pct_change().dropna()
+        if not ret.empty and ret.std() != 0:
+            metrik["Rasio Sharpe"] = (
+                ret.mean() / ret.std() * np.sqrt(len(ret))
+            )
+
+        puncak = eq.cummax()
+        drawdown = (eq - puncak) / puncak
+        metrik["Maksimal Drawdown"] = drawdown.min()
+
+        kurva = pd.DataFrame({"equity": eq, "drawdown": drawdown})
+        return metrik, kurva
+
+    return metrik
+


### PR DESCRIPTION
## Ringkasan
- tambah fungsi perhitungan metrik dasar, waktu tahan, rasio Sharpe, dan drawdown
- dukungan pengembalian kurva ekuitas beserta drawdown ketika data disediakan

## Pengujian
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ddeee76608328bcc78df52262a8f8