### PR TITLE
Tambah optimasi strategi penuh dan update pipeline

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -154,6 +154,7 @@ real_api_secret=xxx
 ```
 
 Strategi dikonfigurasi lewat `config/strategy_params.json`. Model ML akan dilatih otomatis. Untuk manual gunakan `python ml/training.py --symbol BTCUSDT` atau `--symbol all` juga bisa lewat Telegram (`/ml`, `/mltrain`).
+Optimasi strategi kini mencakup semua parameter utama per simbol dan otomatis memperbarui file config setelah proses optimasi selesai.
 
 ### FAQ
 - **Apakah aman restart?** Ya, data di `runtime_state` dipulihkan otomatis.

--- a/backtest/engine.py
+++ b/backtest/engine.py
@@ -41,6 +41,9 @@ def run_backtest(
     equity: list[float] = []
     hold = 0
 
+    trig_pct = config.get("trailing_trigger_pct", 0.5) if config else 0.5
+    off_pct = config.get("trailing_offset_pct", 0.25) if config else 0.25
+
     for i in range(len(df)):
         df_slice = df.iloc[: i + 1].copy()
         df_slice = generate_signals(df_slice, score_threshold, symbol, config)
@@ -55,8 +58,8 @@ def run_backtest(
                 active_trade.entry_price,
                 active_trade.side,
                 active_trade.trailing_sl,
-                0.5,
-                0.25,
+                trig_pct,
+                off_pct,
             )
 
             if check_exit_condition(

--- a/backtest/metrics.py
+++ b/backtest/metrics.py
@@ -45,6 +45,14 @@ def calculate_metrics(
         "Rata-rata Rugi": kalah["pnl"].mean() if not kalah.empty else 0.0,
     }
 
+    # --------------- Profit Factor ---------------
+    total_profit = menang["pnl"].sum()
+    total_loss = abs(kalah["pnl"].sum())
+    if total_loss == 0:
+        metrik["Profit Factor"] = float("inf")
+    else:
+        metrik["Profit Factor"] = total_profit / total_loss
+
     # --------------- Waktu tahan rata-rata ---------------
     if "exit_time" in df.columns and df["exit_time"].notna().any():
         masuk = pd.to_datetime(df["entry_time"])
@@ -66,6 +74,8 @@ def calculate_metrics(
             metrik["Rasio Sharpe"] = (
                 ret.mean() / ret.std() * np.sqrt(len(ret))
             )
+        else:
+            metrik["Rasio Sharpe"] = 0.0
 
         puncak = eq.cummax()
         drawdown = (eq - puncak) / puncak

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -1,54 +1,105 @@
+"""Optimasi parameter strategi secara acak/grid."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
 import random
+
 from backtest.data_loader import load_csv
 from backtest.engine import run_backtest
 from backtest.metrics import calculate_metrics
 
 
+GRID: dict[str, list] = {
+    "ema_period": list(range(5, 51, 5)),
+    "sma_period": list(range(5, 51, 5)),
+    "rsi_period": list(range(10, 31, 5)),
+    "macd_fast": [8, 12, 16],
+    "macd_slow": [20, 26, 36],
+    "macd_signal": [7, 9, 12],
+    "score_threshold": [1.2, 1.5, 1.7, 2.0, 2.2],
+    "trailing_offset_pct": [0.15, 0.20, 0.25, 0.30],
+    "trailing_trigger_pct": [0.4, 0.5, 0.6, 0.7],
+}
+
+
+def _sample_params() -> dict:
+    """Ambil kombinasi parameter secara acak dari GRID."""
+    return {k: random.choice(v) for k, v in GRID.items()}
+
+
 def optimize_strategy(
     symbol: str,
-    n_iter: int = 50,
-    step: int = 5,
+    n_iter: int = 200,
     start: str | None = None,
     end: str | None = None,
     initial_capital: float = 1000,
 ):
-    """Cari kombinasi parameter terbaik menggunakan pencarian acak."""
-    ema_range = list(range(5, 51, step))
-    sma_range = list(range(5, 51, step))
-    rsi_range = list(range(30, 71, step))
+    """Cari kombinasi parameter terbaik dan simpan ke strategy_params.json.
+
+    Prioritas seleksi berdasarkan winrate kemudian Profit Factor.
+    Target minimum: winrate >= 70% dan Profit Factor > 3.
+    """
 
     filepath = f"data/historical_data/1h/{symbol}_1h.csv"
     df = load_csv(filepath, start=start, end=end)
 
-    terbaik_params = None
-    terbaik_metrik = None
-    terbaik_sharpe = float("-inf")
+    terbaik_params: dict | None = None
+    terbaik_metrik: dict | None = None
+    overall_params: dict | None = None
+    overall_metrik: dict | None = None
 
     for _ in range(n_iter):
-        ema = random.choice(ema_range)
-        sma = random.choice(sma_range)
-        rsi_th = random.choice(rsi_range)
-        config = {
-            "ema_period": ema,
-            "sma_period": sma,
-            "rsi_threshold": rsi_th,
-        }
+        params = _sample_params()
         trades, equity, _ = run_backtest(
             df.copy(),
-            initial_capital=initial_capital,
             symbol=symbol,
-            config=config,
+            initial_capital=initial_capital,
+            config=params,
+            score_threshold=params["score_threshold"],
         )
+
         hasil = calculate_metrics(trades, equity)
-        if isinstance(hasil, tuple):
-            metrik, _ = hasil
-        else:
-            metrik = hasil
-        sharpe = metrik.get("Rasio Sharpe", float("-inf"))
-        if sharpe > terbaik_sharpe:
-            terbaik_sharpe = sharpe
-            terbaik_params = config
-            terbaik_metrik = metrik
+        metrik = hasil[0] if isinstance(hasil, tuple) else hasil
+        metrik.setdefault("Rasio Sharpe", 0.0)
+        winrate = metrik.get("Persentase Menang", 0.0)
+        pf = metrik.get("Profit Factor", 0.0)
+
+        if overall_params is None or winrate > overall_metrik.get("Persentase Menang", 0.0):
+            overall_params, overall_metrik = params, metrik
+
+        if winrate < 70.0 or pf <= 3:
+            continue
+
+        if terbaik_params is None:
+            terbaik_params, terbaik_metrik = params, metrik
+            continue
+
+        best_wr = terbaik_metrik.get("Persentase Menang", 0.0)
+        best_pf = terbaik_metrik.get("Profit Factor", 0.0)
+        if winrate > best_wr or (winrate == best_wr and pf > best_pf):
+            terbaik_params, terbaik_metrik = params, metrik
+
+    if terbaik_params is None:
+        logging.warning("Tidak ada kombinasi memenuhi winrate >=70% dan PF>3")
+        return overall_params, overall_metrik
+
+    terbaik_params["trailing_enabled"] = True
+
+    path = os.path.join("config", "strategy_params.json")
+    if os.path.exists(path):
+        with open(path) as f:
+            strategi = json.load(f)
+    else:
+        strategi = {}
+    strategi[symbol] = terbaik_params
+    with open(path, "w") as f:
+        json.dump(strategi, f, indent=2)
 
     return terbaik_params, terbaik_metrik
+
+
+__all__ = ["optimize_strategy"]
 

--- a/ui/backtest_ui.py
+++ b/ui/backtest_ui.py
@@ -196,6 +196,8 @@ if jalankan:
                     continue
             with st.spinner(f"Menjalankan backtest {simbol}"):
                 cfg_sym = STRATEGY_PARAMS.get(simbol, {})
+                if not cfg_sym:
+                    st.warning(f"{simbol} belum memiliki parameter, menggunakan default.")
                 trades, equity, _ = run_backtest(
                     df,
                     symbol=simbol,
@@ -204,6 +206,7 @@ if jalankan:
                     timeframe=tf,
                     initial_capital=initial_capital,
                     config=cfg_sym,
+                    score_threshold=cfg_sym.get("score_threshold", 1.4),
                     risk_per_trade=risk_per_trade,
                     leverage=leverage,
                 )
@@ -217,14 +220,15 @@ if jalankan:
                     v = str(v)
                   col.metric(k, v)
             params = STRATEGY_PARAMS.get(simbol, {})
-            ema_p = params.get("ema_period", "-")
-            sma_p = params.get("sma_period", "-")
-            rsi_th = params.get("rsi_threshold", "-")
-            st.info(f"""
-**Parameter Strategi:**  
-EMA: {ema_p}, SMA: {sma_p}, RSI: {rsi_th}  
+            st.info(
+                f"""
+**Parameter Strategi:**
+EMA: {params.get('ema_period', '-')}, SMA: {params.get('sma_period', '-')}, RSI Period: {params.get('rsi_period', '-')}
+MACD F/S/Signal: {params.get('macd_fast', '-')}/{params.get('macd_slow', '-')}/{params.get('macd_signal', '-')}
+Score Th: {params.get('score_threshold', '-')}, Trail Off/Trig: {params.get('trailing_offset_pct', '-')}/{params.get('trailing_trigger_pct', '-')}
 Timeframe: {tf} | Initial Capital: ${initial_capital} | Risk/Trade: {risk_per_trade}% | Leverage: {leverage}x
-""")
+"""
+            )
             if kurva is not None:
                 fig = go.Figure()
                 fig.add_trace(


### PR DESCRIPTION
## Ringkasan
- tambahkan grid search acak untuk semua parameter strategi dan simpan hasilnya ke `strategy_params.json`
- perhitungan metrik kini menyertakan Profit Factor dan nilai Sharpe default 0 jika tidak valid
- UI backtest memuat parameter per simbol, termasuk score threshold dan trailing, serta menampilkan semua param di hasil

## Pengujian
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68902a6c6e74832883b24a2c6aa42a86