### PR TITLE
Perbaiki manajemen data historis

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -66,6 +66,18 @@ Selama backtest berjalan, akan muncul peringatan agar tidak me-refresh halaman s
     pytest tests/
     ```
 
+### Persiapan Data Historical
+
+Pastikan folder penyimpanan data historis tersedia dan dapat ditulis:
+
+```bash
+sudo mkdir -p data/historical_data/5m
+sudo chown -R 1000:1000 data/historical_data
+sudo chmod -R u+w data/historical_data
+```
+
+Optimasi dan training akan otomatis memakai data yang sudah ada, melakukan konversi timeframe jika memungkinkan, dan hanya mengunduh baru bila diperlukan.
+
 ---
 
 ## 🔧 **Fitur Utama**

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -7,9 +7,9 @@ import logging
 import os
 import random
 
-from backtest.data_loader import load_csv
 from backtest.engine import run_backtest
 from backtest.metrics import calculate_metrics
+from utils.historical_data import load_historical_data
 
 
 GRID: dict[str, list] = {
@@ -32,9 +32,10 @@ def _sample_params() -> dict:
 
 def optimize_strategy(
     symbol: str,
+    tf: str,
+    start: str,
+    end: str,
     n_iter: int = 200,
-    start: str | None = None,
-    end: str | None = None,
     initial_capital: float = 1000,
 ):
     """Cari kombinasi parameter terbaik dan simpan ke strategy_params.json.
@@ -43,8 +44,7 @@ def optimize_strategy(
     Target minimum: winrate >= 70% dan Profit Factor > 3.
     """
 
-    filepath = f"data/historical_data/1h/{symbol}_1h.csv"
-    df = load_csv(filepath, start=start, end=end)
+    df = load_historical_data(symbol, tf, start, end)
 
     terbaik_params: dict | None = None
     terbaik_metrik: dict | None = None
@@ -59,6 +59,9 @@ def optimize_strategy(
             initial_capital=initial_capital,
             config=params,
             score_threshold=params["score_threshold"],
+            timeframe=tf,
+            start=start,
+            end=end,
         )
 
         hasil = calculate_metrics(trades, equity)

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ import utils.bot_flags as bot_flags
 from database.sqlite_logger import init_db
 from ml import training, historical_trainer
 from utils.config_loader import load_global_config, save_global_config
+from utils.historical_data import MAX_DAYS
 
 # === SETUP ===
 nest_asyncio.apply()
@@ -215,7 +216,11 @@ def train_selected_symbols(symbols):
             if use_existing:
                 acc = training.train_model(sym, tf)
             else:
-                res = historical_trainer.train_from_history(sym, tf)
+                end = pd.Timestamp.utcnow().date().isoformat()
+                start = (
+                    pd.Timestamp.utcnow() - pd.Timedelta(days=MAX_DAYS.get(tf, 30))
+                ).date().isoformat()
+                res = historical_trainer.train_from_history(sym, tf, start, end)
                 acc = res.get("train_accuracy", 0.0) if res else 0.0
             results[sym] = acc
             status.update(label=f"{sym} selesai: {acc:.2%}")

--- a/ml/historical_trainer.py
+++ b/ml/historical_trainer.py
@@ -1,6 +1,5 @@
 import os
 import logging
-import time
 import datetime as dt
 import pickle
 from pathlib import Path
@@ -8,7 +7,6 @@ from typing import Tuple, Optional
 import argparse
 
 import pandas as pd
-import requests
 from ta.trend import EMAIndicator, SMAIndicator, MACD
 from ta.momentum import RSIIndicator
 from sklearn.metrics import accuracy_score
@@ -16,75 +14,7 @@ from sklearn.metrics import accuracy_score
 from ml import training
 from notifications.notifier import kirim_notifikasi_ml_training
 from utils.config_loader import load_global_config
-
-
-BINANCE_URL = "https://api.binance.com/api/v3/klines"
-LIMIT = 1000
-
-
-def _fetch_historical_klines(symbol: str, timeframe: str, days: int = 30) -> pd.DataFrame:
-    """Unduh data klines Binance selama `days` hari."""
-    end_ts = int(dt.datetime.utcnow().timestamp() * 1000)
-    start_ts = end_ts - days * 24 * 60 * 60 * 1000
-    all_klines = []
-    current = start_ts
-    mult = int(timeframe.rstrip("m"))
-    max_len = days * (24 * 60 // mult)
-    logging.info("[ML] Mengambil data %s %s dari Binance", symbol.upper(), timeframe)
-
-    while current < end_ts and len(all_klines) < max_len:
-        params = {
-            "symbol": symbol.upper(),
-            "interval": timeframe,
-            "limit": LIMIT,
-            "startTime": current,
-        }
-        try:
-            resp = requests.get(BINANCE_URL, params=params, timeout=10)
-            if resp.status_code != 200:
-                logging.error("Gagal request Binance: %s", resp.text)
-                return pd.DataFrame()
-            data = resp.json()
-        except Exception as exc:
-            logging.error("Error koneksi ke Binance: %s", exc)
-            return pd.DataFrame()
-
-        if not data:
-            break
-        all_klines.extend(data)
-        last_open = data[-1][0]
-        current = last_open + mult * 60_000
-        time.sleep(0.1)
-
-    if not all_klines:
-        logging.error("Data kosong dari Binance")
-        return pd.DataFrame()
-
-    df = pd.DataFrame(
-        all_klines,
-        columns=[
-            "time",
-            "open",
-            "high",
-            "low",
-            "close",
-            "volume",
-            "close_time",
-            "quote_asset_volume",
-            "trades",
-            "taker_buy_base",
-            "taker_buy_quote",
-            "ignore",
-        ],
-    )
-    df = df[["time", "open", "high", "low", "close", "volume"]]
-    df["time"] = pd.to_datetime(df["time"], unit="ms")
-    numeric_cols = ["open", "high", "low", "close", "volume"]
-    df[numeric_cols] = df[numeric_cols].astype(float)
-    logging.info("[ML] Dapat %d baris", len(df))
-    return df
-
-
+from utils.historical_data import load_historical_data, MAX_DAYS
 def _apply_indicators(df: pd.DataFrame) -> pd.DataFrame:
     close = pd.to_numeric(df["close"], errors="coerce")
     df["ema"] = EMAIndicator(close, window=14).ema_indicator()
@@ -108,7 +38,12 @@ def _label_data(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def label_and_save(symbol: str, timeframe: str | None = None) -> bool:
+def label_and_save(
+    symbol: str,
+    timeframe: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> bool:
     """Pastikan data CSV suatu simbol memiliki kolom label."""
     data_dir = Path("data/training_data")
     data_dir.mkdir(parents=True, exist_ok=True)
@@ -129,10 +64,15 @@ def label_and_save(symbol: str, timeframe: str | None = None) -> bool:
             logging.error("[ML] Kolom wajib tidak lengkap di %s", csv_path)
             return False
     else:
-        df = _fetch_historical_klines(symbol, tf)
+        if end_date is None:
+            end_date = dt.datetime.utcnow().date().isoformat()
+        if start_date is None:
+            start_date = (pd.to_datetime(end_date) - pd.Timedelta(days=30)).date().isoformat()
+        df = load_historical_data(symbol, tf, start_date, end_date)
         if df.empty:
             logging.error("[ML] Data %s tidak tersedia untuk labeling", symbol)
             return False
+        df = df.reset_index().rename(columns={"timestamp": "time"})
 
     df = _apply_indicators(df)
     df = _label_data(df)
@@ -147,14 +87,19 @@ def label_and_save(symbol: str, timeframe: str | None = None) -> bool:
     return True
 
 
-def _prepare_training_data(symbol: str, timeframe: str) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    df = _fetch_historical_klines(symbol, timeframe)
+def _prepare_training_data(
+    symbol: str, timeframe: str, start_date: str, end_date: str
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    df = load_historical_data(symbol, timeframe, start_date, end_date)
     if df.empty:
         logging.error("Data %s tidak tersedia", symbol)
         return pd.DataFrame(), pd.DataFrame()
 
-    df["time"] = pd.to_datetime(df["time"], errors="coerce")
+    df = df.copy()
+    df.reset_index(inplace=True)
+    df.rename(columns={"timestamp": "time"}, inplace=True)
     num_cols = ["open", "high", "low", "close", "volume"]
+    df["time"] = pd.to_datetime(df["time"], errors="coerce")
     df[num_cols] = df[num_cols].apply(pd.to_numeric, errors="coerce")
     df = df.dropna(subset=["time"] + num_cols)
 
@@ -174,11 +119,22 @@ def _prepare_training_data(symbol: str, timeframe: str) -> Tuple[pd.DataFrame, p
     return train_df, eval_df
 
 
-def train_from_history(symbol: str, timeframe: str | None = None) -> Optional[dict]:
+def train_from_history(
+    symbol: str,
+    timeframe: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> Optional[dict]:
     """Unduh data historis, latih model, dan kembalikan hasil."""
     tf = timeframe or load_global_config().get("selected_timeframe", "5m")
+    if end_date is None:
+        end_date = dt.datetime.utcnow().date().isoformat()
+    if start_date is None:
+        start_date = (
+            pd.to_datetime(end_date) - pd.Timedelta(days=MAX_DAYS.get(tf, 30))
+        ).date().isoformat()
     logging.info("[ML] Mulai proses training %s %s", symbol.upper(), tf)
-    train_df, eval_df = _prepare_training_data(symbol, tf)
+    train_df, eval_df = _prepare_training_data(symbol, tf, start_date, end_date)
     if train_df.empty:
         msg = f"Data training {symbol.upper()} tidak mencukupi"
         logging.error(msg)
@@ -223,8 +179,10 @@ def main():
     parser = argparse.ArgumentParser(description="Labeling data historis untuk ML")
     parser.add_argument("--symbol", required=True, help="Simbol, mis. BTCUSDT")
     parser.add_argument("--timeframe", "-t", default=None, help="Timeframe data")
+    parser.add_argument("--start", required=False, help="Tanggal mulai (YYYY-MM-DD)")
+    parser.add_argument("--end", required=False, help="Tanggal akhir (YYYY-MM-DD)")
     args = parser.parse_args()
-    if not label_and_save(args.symbol.upper(), args.timeframe):
+    if not label_and_save(args.symbol.upper(), args.timeframe, args.start, args.end):
         raise SystemExit(1)
 
 

--- a/notifications/command_handler.py
+++ b/notifications/command_handler.py
@@ -8,6 +8,7 @@ import pandas as pd
 from ml.training import train_model, MIN_DATA, FEATURE_COLS
 from ml import historical_trainer
 from utils.config_loader import load_global_config
+from utils.historical_data import MAX_DAYS
 import matplotlib.pyplot as plt
 from database.sqlite_logger import get_all_trades, export_trades_csv
 from notifications.notifier import kirim_notifikasi_telegram
@@ -66,7 +67,9 @@ def _train_symbol(symbol: str, timeframe: str | None = None) -> float:
         except Exception as e:
             logging.error(f"Training model {symbol} gagal: {e}")
             return 0.0
-    result = historical_trainer.train_from_history(symbol, tf)
+    end = pd.Timestamp.utcnow().date().isoformat()
+    start = (pd.Timestamp.utcnow() - pd.Timedelta(days=MAX_DAYS.get(tf, 30))).date().isoformat()
+    result = historical_trainer.train_from_history(symbol, tf, start, end)
     return result.get("train_accuracy", 0.0) if result else 0.0
 
 

--- a/strategies/scalping_strategy.py
+++ b/strategies/scalping_strategy.py
@@ -8,6 +8,7 @@ import os
 import logging
 
 from utils.config_loader import load_global_config
+from utils.historical_data import MAX_DAYS
 
 MODEL_PATH = "models/model_scalping.pkl"
 _ml_models: dict[str, ClassifierMixin | None] = {}
@@ -44,7 +45,11 @@ def load_ml_model(symbol: str, path: str | None = None, timeframe: str | None = 
         logging.info(f"Auto-training model untuk {symbol}...")
         try:
             from ml import historical_trainer
-            historical_trainer.train_from_history(symbol)
+            end = pd.Timestamp.utcnow().date().isoformat()
+            start = (
+                pd.Timestamp.utcnow() - pd.Timedelta(days=MAX_DAYS.get(tf, 30))
+            ).date().isoformat()
+            historical_trainer.train_from_history(symbol, tf, start, end)
         except Exception as e:  # pragma: no cover - training bisa gagal
             logging.error(f"Auto-training gagal: {e}")
         _auto_trained.add(symbol)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -2,7 +2,9 @@ from backtest.optimizer import optimize_strategy
 
 
 def test_optimize_strategy_runs():
-    params, metrics = optimize_strategy("BTCUSDT", n_iter=1)
+    params, metrics = optimize_strategy(
+        "BTCUSDT", "1h", "2025-07-01", "2025-07-02", n_iter=1
+    )
     assert "ema_period" in params
     assert "Rasio Sharpe" in metrics
 

--- a/ui/backtest_ui.py
+++ b/ui/backtest_ui.py
@@ -14,6 +14,7 @@ from backtest.metrics import calculate_metrics
 from backtest.optimizer import optimize_strategy
 from ml import training
 from ml.historical_trainer import label_and_save
+from utils.historical_data import MAX_DAYS
 
 st.set_page_config(page_title="Backtest Multi-Simbol")
 st.title("Backtest Multi-Simbol")
@@ -78,6 +79,12 @@ with kol1:
 with kol2:
     tanggal_akhir = st.date_input("Tanggal Akhir", dt.date.today())
 
+if (tanggal_akhir - tanggal_mulai).days > MAX_DAYS.get(tf, 30):
+    st.error(
+        f"Rentang tanggal terlalu panjang untuk TF {tf}. Maksimum {MAX_DAYS.get(tf, 30)} hari."
+    )
+    st.stop()
+
 if "backtest_running" not in st.session_state:
     st.session_state.backtest_running = False
 
@@ -108,7 +115,9 @@ if do_optimize:
         for simbol in simbol_terpilih:
             with st.spinner(f"Optimasi {simbol}..."):
                 try:
-                    best_param, best_metrik = optimize_strategy(simbol)
+                    best_param, best_metrik = optimize_strategy(
+                        simbol, tf, str(tanggal_mulai), str(tanggal_akhir)
+                    )
                     STRATEGY_PARAMS[simbol] = best_param or {}
                     with open(STRAT_PATH, "w") as f:
                         json.dump(STRATEGY_PARAMS, f, indent=2)
@@ -206,7 +215,9 @@ if jalankan:
             if not params:
                 with st.spinner(f"Otomatis optimasi param {simbol}..."):
                     try:
-                        params, met_opt = optimize_strategy(simbol)
+                        params, met_opt = optimize_strategy(
+                            simbol, tf, str(tanggal_mulai), str(tanggal_akhir)
+                        )
                         STRATEGY_PARAMS[simbol] = params or {}
                         with open(STRAT_PATH, "w") as f:
                             json.dump(STRATEGY_PARAMS, f, indent=2)

--- a/utils/historical_data.py
+++ b/utils/historical_data.py
@@ -1,0 +1,144 @@
+import os
+import logging
+import time
+import datetime as dt
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+import requests
+
+BINANCE_URL = "https://api.binance.com/api/v3/klines"
+LIMIT = 1000
+
+MAX_DAYS: Dict[str, int] = {"1m": 60, "5m": 90, "15m": 120, "1h": 180}
+
+TF_ORDER = ["1m", "5m", "15m", "1h"]
+TF_TO_PANDAS = {"1m": "1T", "5m": "5T", "15m": "15T", "1h": "1H"}
+
+
+def _download_binance(symbol: str, tf: str, start_dt: pd.Timestamp, end_dt: pd.Timestamp) -> pd.DataFrame:
+    """Unduh data historis dari Binance sesuai rentang waktu."""
+    start_ts = int(start_dt.timestamp() * 1000)
+    end_ts = int(end_dt.timestamp() * 1000)
+    mult = 1
+    if tf.endswith("m"):
+        mult = int(tf.rstrip("m"))
+    elif tf.endswith("h"):
+        mult = int(tf.rstrip("h")) * 60
+
+    all_klines = []
+    current = start_ts
+    while current < end_ts:
+        params = {
+            "symbol": symbol.upper(),
+            "interval": tf,
+            "limit": LIMIT,
+            "startTime": current,
+            "endTime": end_ts,
+        }
+        try:
+            resp = requests.get(BINANCE_URL, params=params, timeout=10)
+            if resp.status_code != 200:
+                logging.error("Gagal request Binance: %s", resp.text)
+                break
+            data = resp.json()
+        except Exception as exc:  # pragma: no cover - jaringan
+            logging.error("Error koneksi ke Binance: %s", exc)
+            break
+        if not data:
+            break
+        all_klines.extend(data)
+        current = data[-1][0] + mult * 60_000
+        time.sleep(0.1)
+
+    if not all_klines:
+        return pd.DataFrame()
+
+    df = pd.DataFrame(
+        all_klines,
+        columns=[
+            "time",
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+            "close_time",
+            "quote_asset_volume",
+            "trades",
+            "taker_buy_base",
+            "taker_buy_quote",
+            "ignore",
+        ],
+    )
+    df = df[["time", "open", "high", "low", "close", "volume"]]
+    df["timestamp"] = pd.to_datetime(df["time"], unit="ms")
+    df.drop(columns=["time"], inplace=True)
+    for col in ["open", "high", "low", "close", "volume"]:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+    df.set_index("timestamp", inplace=True)
+    return df
+
+
+def load_historical_data(symbol: str, tf: str, start_date: str, end_date: str) -> pd.DataFrame:
+    """Muat data historis sesuai aturan folder dan validasi rentang."""
+    start_dt = pd.to_datetime(start_date)
+    end_dt = pd.to_datetime(end_date)
+    if tf not in MAX_DAYS:
+        raise ValueError(f"Timeframe tidak didukung: {tf}")
+    if (end_dt - start_dt).days > MAX_DAYS[tf]:
+        raise ValueError(
+            f"Rentang tanggal terlalu panjang untuk TF {tf}. Maksimum {MAX_DAYS[tf]} hari."
+        )
+
+    folder = Path("data") / "historical_data" / tf
+    try:
+        os.makedirs(folder, exist_ok=True)
+    except Exception as e:
+        logging.error(f"Gagal membuat folder '{folder}': {e}")
+        raise RuntimeError(
+            f"Permission error. Pastikan folder {folder} dapat ditulis user docker. Jalankan: sudo chown -R 1000:1000 data/historical_data"
+        )
+
+    filepath = folder / f"{symbol}_{tf}.csv"
+    if filepath.exists():
+        try:
+            df = pd.read_csv(filepath, parse_dates=["timestamp"], index_col="timestamp")
+        except Exception:
+            df = pd.DataFrame()
+        else:
+            if not df.empty and df.index.min() <= start_dt and df.index.max() >= end_dt:
+                return df.loc[start_dt:end_dt]
+
+    idx = TF_ORDER.index(tf)
+    for smaller in TF_ORDER[:idx]:
+        src = Path("data") / "historical_data" / smaller / f"{symbol}_{smaller}.csv"
+        if src.exists():
+            try:
+                df_small = pd.read_csv(src, parse_dates=["timestamp"], index_col="timestamp")
+            except Exception:
+                continue
+            df_resampled = (
+                df_small
+                .resample(TF_TO_PANDAS[tf])
+                .agg({
+                    "open": "first",
+                    "high": "max",
+                    "low": "min",
+                    "close": "last",
+                    "volume": "sum",
+                })
+                .dropna()
+            )
+            df_resampled.to_csv(filepath)
+            if df_resampled.index.min() <= start_dt and df_resampled.index.max() >= end_dt:
+                return df_resampled.loc[start_dt:end_dt]
+
+    df_dl = _download_binance(symbol, tf, start_dt, end_dt)
+    if df_dl.empty:
+        return df_dl
+    df_dl.to_csv(filepath)
+    return df_dl.loc[start_dt:end_dt]
+
+__all__ = ["load_historical_data", "MAX_DAYS"]


### PR DESCRIPTION
## Ringkasan
- Tambah modul `historical_data` untuk muat data dengan validasi rentang, pembuatan folder otomatis, konversi timeframe, dan fallback unduh Binance
- Perbarui pipeline optimasi, training, dan UI agar menerima `timeframe`, `start_date`, dan `end_date`
- Tambah dokumentasi persiapan folder `data/historical_data` beserta instruksi perizinan

## Pengujian
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68904978eaf483288316fa4d82c04cc9