### PR TITLE
tambah validasi jumlah bar dan catatan dokumentasi

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,6 +80,8 @@ sudo chmod -R u+w data/historical_data
 
 Optimasi dan training akan otomatis memakai data yang sudah ada, melakukan konversi timeframe jika memungkinkan, dan hanya mengunduh baru bila diperlukan.
 
+> **Catatan:** Konfirmasi multi-timeframe membutuhkan minimal 20–30 bar pada timeframe lebih besar (15m/1h), pastikan data historis yang diambil memenuhi syarat tersebut.
+
 ---
 
 ## 🔧 **Fitur Utama**

--- a/strategies/scalping_strategy.py
+++ b/strategies/scalping_strategy.py
@@ -148,7 +148,25 @@ def confirm_by_higher_tf(df, config=None):
     df15 = df.resample('15T').agg(ohlc).dropna()
     if df15.empty:
         return True, True
-    df15 = apply_indicators(df15, config)
+
+    min_window = max(
+        config.get('ema_period', 20),
+        config.get('sma_period', 20),
+        config.get('rsi_period', 14),
+        config.get('macd_slow', 26),
+        20,
+    )
+    if len(df15) < min_window:
+        logging.warning(
+            "Data terlalu pendek untuk konfirmasi indikator di TF lebih besar. Tambah range data!"
+        )
+        return True, True
+
+    try:
+        df15 = apply_indicators(df15, config)
+    except Exception as e:
+        logging.warning(f"apply_indicators gagal (resample 15m): {e}")
+        return True, True
     rsi_th = config.get('rsi_threshold', 40)
     long_ok = (
         (df15['ema'] > df15['sma'])


### PR DESCRIPTION
## Ringkasan
- tambahkan pengecekan jumlah bar minimum sebelum hitung indikator konfirmasi timeframe lebih besar
- tambahkan penanganan error pada apply_indicators agar proses tidak terhenti
- dokumentasikan kebutuhan minimal 20–30 bar untuk konfirmasi multi-timeframe

## Pengujian
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68918a09d6e48328bd4ab2df929fa40c