### PR TITLE
fallback simpan param strategi saat izin ditolak

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -177,6 +177,13 @@ Strategi dikonfigurasi lewat `config/strategy_params.json`. Model ML akan dilati
 Optimasi strategi kini mencakup semua parameter utama per simbol dan otomatis memperbarui file config setelah proses optimasi selesai.
 Kini UI backtest mendukung Optimasi Parameter per-simbol. Jika parameter belum ada, sistem akan otomatis optimasi sebelum backtest.
 
+Jika penyimpanan ke `config/strategy_params.json` gagal karena izin, parameter optimal tetap tersedia di memori untuk sesi berjalan. Unduh manual atau perbaiki izin dengan:
+
+```
+sudo chown -R 1000:1000 config
+sudo chmod -R u+w config
+```
+
 ### FAQ
 - **Apakah aman restart?** Ya, data di `runtime_state` dipulihkan otomatis.
 - **Bagaimana menghindari rate limit?** Semua panggilan Binance melalui `utils/safe_api.py`.


### PR DESCRIPTION
## Ringkasan
- simpan parameter terbaik di memori dan tampilkan pesan saat gagal menyimpan ke berkas
- UI backtest memakai parameter dari memori serta memberi instruksi perbaikan izin dan tombol unduh
- dokumentasi menambahkan panduan perbaikan izin bila penyimpanan konfigurasi gagal

## Pengujian
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68919677e5fc832883511c70bc6d5962