### PR TITLE
Tambahkan perhitungan ATR dan lebar Bollinger

### DIFF
--- a/main.py
+++ b/main.py
@@ -216,12 +216,17 @@ def train_selected_symbols(symbols):
             if os.path.exists(csv_path):
                 try:
                     df = pd.read_csv(csv_path)
+                    missing = [c for c in training.FEATURE_COLS if c not in df.columns]
+                    if missing:
+                        df = training.prepare_features(df)
+                        missing = [c for c in training.FEATURE_COLS if c not in df.columns]
+                    if missing:
+                        logging.error(f"[ML] Kolom fitur hilang di {csv_path}: {missing}")
+                    elif "label" in df.columns and len(df.dropna(subset=training.FEATURE_COLS + ["label"])) >= training.MIN_DATA:
+                        use_existing = True
                 except Exception as e:
                     df = pd.DataFrame()
                     logging.error(f"[ML] Gagal membaca {csv_path}: {e}")
-                else:
-                    if "label" in df.columns and len(df.dropna(subset=training.FEATURE_COLS + ["label"])) >= training.MIN_DATA:
-                        use_existing = True
 
             if use_existing:
                 acc = training.train_model(sym, tf)

--- a/ml/feature_generator.py
+++ b/ml/feature_generator.py
@@ -1,0 +1,28 @@
+import pandas as pd
+from ta.trend import EMAIndicator, SMAIndicator, MACD
+from ta.momentum import RSIIndicator
+from ta.volatility import AverageTrueRange, BollingerBands
+
+
+def prepare_features(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    if not {"close", "high", "low"}.issubset(df.columns):
+        return df
+
+    close = pd.to_numeric(df["close"], errors="coerce")
+    high = pd.to_numeric(df["high"], errors="coerce")
+    low = pd.to_numeric(df["low"], errors="coerce")
+
+    df["ema"] = EMAIndicator(close, window=14).ema_indicator()
+    df["sma"] = SMAIndicator(close, window=14).sma_indicator()
+    macd = MACD(close)
+    df["macd"] = macd.macd()
+    df["rsi"] = RSIIndicator(close, window=14).rsi()
+
+    atr = AverageTrueRange(high, low, close, window=14).average_true_range()
+    df["atr"] = atr
+
+    bb = BollingerBands(close, window=20, window_dev=2)
+    df["bb_width"] = (bb.bollinger_hband() - bb.bollinger_lband()) / close
+
+    return df


### PR DESCRIPTION
## Ringkasan
- buat modul `prepare_features` untuk menghitung indikator termasuk ATR dan lebar Bollinger
- validasi kolom fitur saat memuat dataset dan tangani jika tidak lengkap
- periksa fitur sebelum memakai data training existing

## Pengujian
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892be2b7570832895e99c04bb7ec1d3