### PR TITLE
dukungan parameter manual per simbol

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -182,11 +182,13 @@ Konfigurasi tambahan tersedia di `config/strategy.json`:
 ```
 {
   "enable_optimizer": true,
-  "manual_parameters": { ... }
+  "manual_parameters": {
+    "DEFAULT": { ... }
+  }
 }
 ```
 
-Jika `enable_optimizer` bernilai `false`, proses optimasi dilewati dan nilai pada `manual_parameters` dipakai. Anda perlu mengisi parameter indikator secara manual lewat UI backtest. Bila diaktifkan, backend akan mencari kombinasi optimal secara otomatis (proses ini dapat memakan waktu dan CPU).
+Mulai sekarang, parameter manual indikator bisa diatur spesifik untuk setiap simbol. Form UI akan otomatis menyesuaikan. Jika `enable_optimizer` bernilai `false`, proses optimasi dilewati dan setiap simbol menggunakan parameter manual masing-masing. Bila diaktifkan, backend akan mencari kombinasi optimal secara otomatis (proses ini dapat memakan waktu dan CPU).
 
 Jika penyimpanan ke `config/strategy_params.json` gagal karena izin, parameter optimal tetap tersedia di memori untuk sesi berjalan. Unduh manual atau perbaiki izin dengan:
 

--- a/backtest/optimizer.py
+++ b/backtest/optimizer.py
@@ -85,7 +85,8 @@ def optimize_strategy(
 
     cfg_strategy = load_strategy_config()
     if not cfg_strategy.get("enable_optimizer", True):
-        return cfg_strategy.get("manual_parameters", {}), {}
+        manual = cfg_strategy.get("manual_parameters", {})
+        return manual.get(symbol, manual.get("DEFAULT", {})), {}
 
     n_iter = n_iter or int(os.getenv("N_ITER", 30))
     n_jobs = n_jobs or int(os.getenv("N_JOBS", 2))

--- a/config/strategy.json
+++ b/config/strategy.json
@@ -1,14 +1,16 @@
 {
   "enable_optimizer": true,
   "manual_parameters": {
-    "ema_period": 5,
-    "sma_period": 22,
-    "macd_fast": 12,
-    "macd_slow": 26,
-    "macd_signal": 9,
-    "rsi_period": 14,
-    "bb_window": 20,
-    "atr_window": 14,
-    "score_threshold": 1.8
+    "DEFAULT": {
+      "ema_period": 5,
+      "sma_period": 22,
+      "macd_fast": 12,
+      "macd_slow": 26,
+      "macd_signal": 9,
+      "rsi_period": 14,
+      "bb_window": 20,
+      "atr_window": 14,
+      "score_threshold": 1.8
+    }
   }
 }

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -16,15 +16,17 @@ def test_optimize_strategy_manual(monkeypatch, tmp_path):
     cfg = {
         "enable_optimizer": False,
         "manual_parameters": {
-            "ema_period": 5,
-            "sma_period": 22,
-            "macd_fast": 12,
-            "macd_slow": 26,
-            "macd_signal": 9,
-            "rsi_period": 14,
-            "bb_window": 20,
-            "atr_window": 14,
-            "score_threshold": 1.8,
+            "BTCUSDT": {
+                "ema_period": 5,
+                "sma_period": 22,
+                "macd_fast": 12,
+                "macd_slow": 26,
+                "macd_signal": 9,
+                "rsi_period": 14,
+                "bb_window": 20,
+                "atr_window": 14,
+                "score_threshold": 1.8,
+            }
         },
     }
     cfg_path = tmp_path / "strategy.json"
@@ -41,7 +43,7 @@ def test_optimize_strategy_manual(monkeypatch, tmp_path):
     params, metrics = opt_mod.optimize_strategy(
         "BTCUSDT", "1h", "2025-07-01", "2025-07-02", n_iter=1
     )
-    assert params == cfg["manual_parameters"]
+    assert params == cfg["manual_parameters"]["BTCUSDT"]
     assert metrics == {}
 
 

--- a/tests/test_strategy_config.py
+++ b/tests/test_strategy_config.py
@@ -1,6 +1,7 @@
 import pytest
 
 from utils.strategy_config import validate_manual_params
+from utils import strategy_config
 
 
 def test_validate_manual_params_ok():
@@ -22,3 +23,24 @@ def test_validate_manual_params_fail():
     params = {"ema_period": 0}
     with pytest.raises(ValueError):
         validate_manual_params(params)
+
+
+def test_load_strategy_config_default(monkeypatch, tmp_path):
+    cfg_path = tmp_path / "strategy.json"
+    monkeypatch.setattr(strategy_config, "STRATEGY_CFG_PATH", str(cfg_path))
+    cfg = strategy_config.load_strategy_config()
+    assert "DEFAULT" in cfg["manual_parameters"]
+    assert cfg["manual_parameters"]["DEFAULT"]["ema_period"] == 5
+
+
+def test_save_and_load_multi_symbol(monkeypatch, tmp_path):
+    cfg_path = tmp_path / "strategy.json"
+    monkeypatch.setattr(strategy_config, "STRATEGY_CFG_PATH", str(cfg_path))
+    cfg_in = {
+        "enable_optimizer": False,
+        "manual_parameters": {"BTCUSDT": {"ema_period": 10, "sma_period": 20}},
+    }
+    strategy_config.save_strategy_config(cfg_in)
+    cfg_out = strategy_config.load_strategy_config()
+    assert cfg_out["manual_parameters"]["BTCUSDT"]["ema_period"] == 10
+    assert cfg_out["enable_optimizer"] is False


### PR DESCRIPTION
## Ringkasan
- refactor config dan loader agar `manual_parameters` menjadi dictionary per simbol dengan fallback `DEFAULT`
- UI backtest menampilkan dan menyimpan parameter manual per simbol serta menampilkan pesan perbaikan izin
- tambah unit test untuk load/save config per simbol dan penyesuaian optimizer

## Pengujian
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892ca8209c4832885d315a08d0e9970