### PR TITLE
Tambahkan scrubber posisi residual reduce-only

### DIFF
--- a/execution/order_router.py
+++ b/execution/order_router.py
@@ -129,6 +129,40 @@ def adjust_quantity_to_min(symbol, quantity, price, symbol_filters):
 
     return qty
 
+
+def flatten_residual_position(client, symbol, symbol_filters, max_attempts: int = 2):
+    """Bersihkan sisa posisi menggunakan order market reduce-only."""
+    step = symbol_filters.get(symbol, {}).get("stepSize") or symbol_filters.get(symbol, {}).get("step", 0.0)
+    min_qty = symbol_filters.get(symbol, {}).get("minQty", 0.0)
+    min_notional = symbol_filters.get(symbol, {}).get("minNotional", 0.0)
+    price = get_mark_price(client, symbol)
+    if price is None:
+        return
+    for _ in range(max_attempts):
+        pos = safe_api_call_with_retry(client.futures_position_information, symbol=symbol)
+        if not pos:
+            return
+        amt = float(pos[0].get("positionAmt", 0.0))
+        if abs(amt) < 1e-9:
+            return
+        qty = max(abs(amt), min_qty)
+        if step:
+            qty = math.floor(qty / step) * step
+        if min_notional and price * qty < min_notional:
+            if step:
+                qty = math.ceil(min_notional / price / step) * step
+            else:
+                qty = min_notional / price
+        side = SIDE_SELL if amt > 0 else SIDE_BUY
+        safe_api_call_with_retry(
+            client.futures_create_order,
+            symbol=symbol,
+            side=side,
+            type=ORDER_TYPE_MARKET,
+            quantity=qty,
+            reduceOnly=True,
+        )
+
 def get_mark_price(client, symbol):
     """Ambil harga mark price futures untuk eksekusi close/stop yang aman."""
     result = safe_api_call_with_retry(client.futures_mark_price, symbol=symbol)
@@ -172,6 +206,7 @@ def safe_close_order_market(client, symbol, side, qty, symbol_steps, max_slippag
                 quantity=qty_adj
             )
             if order:
+                flatten_residual_position(client, symbol, symbol_steps)
                 return order
         except ClientError as e:
             if "2021" in str(e) or "2019" in str(e):

--- a/tests/test_dust_scrubber.py
+++ b/tests/test_dust_scrubber.py
@@ -1,0 +1,36 @@
+from unittest.mock import MagicMock
+from execution import order_router as orouter
+
+
+def setup_client(position_side_effect):
+    client = MagicMock()
+    client.futures_position_information.side_effect = position_side_effect
+    client.futures_create_order = MagicMock()
+    return client
+
+
+def test_flatten_residual_min_qty(monkeypatch):
+    client = setup_client([
+        [{'positionAmt': '0.0004'}],
+        [{'positionAmt': '0'}],
+    ])
+    monkeypatch.setattr(orouter, 'safe_api_call_with_retry', lambda func, **kw: func(**kw))
+    monkeypatch.setattr(orouter, 'get_mark_price', lambda c, s: 10000.0)
+    filters = {'BTCUSDT': {'minQty': 0.001, 'stepSize': 0.001, 'minNotional': 5}}
+    orouter.flatten_residual_position(client, 'BTCUSDT', filters)
+    client.futures_create_order.assert_called_once_with(
+        symbol='BTCUSDT', side='SELL', type='MARKET', quantity=0.001, reduceOnly=True
+    )
+
+
+def test_flatten_residual_retry(monkeypatch):
+    client = setup_client([
+        [{'positionAmt': '0.0025'}],
+        [{'positionAmt': '0.0012'}],
+    ])
+    monkeypatch.setattr(orouter, 'safe_api_call_with_retry', lambda func, **kw: func(**kw))
+    monkeypatch.setattr(orouter, 'get_mark_price', lambda c, s: 10000.0)
+    filters = {'BTCUSDT': {'minQty': 0.001, 'stepSize': 0.001, 'minNotional': 5}}
+    orouter.flatten_residual_position(client, 'BTCUSDT', filters)
+    assert client.futures_create_order.call_count == 2
+

--- a/utils/data_provider.py
+++ b/utils/data_provider.py
@@ -69,10 +69,14 @@ def load_symbol_filters(client, coins):
                     )
 
                     if lot_filter and notional_filter:
+                        step_size = float(lot_filter.get('stepSize', 0))
                         symbol_filters[s['symbol']] = {
                             'minQty': float(lot_filter.get('minQty', 0)),
-                            'stepSize': float(lot_filter.get('stepSize', 0)),
-                            'minNotional': float(notional_filter.get('minNotional', notional_filter.get('notional', 0)))
+                            'stepSize': step_size,
+                            'step': step_size,
+                            'minNotional': float(
+                                notional_filter.get('minNotional', notional_filter.get('notional', 0))
+                            )
                         }
                 except Exception as e:
                     st.warning(f"Error processing filters for {s.get('symbol')}: {str(e)}")


### PR DESCRIPTION
## Ringkasan
- tambah alias `step` pada filter simbol
- tambahkan fungsi `flatten_residual_position` dan panggil otomatis saat penutupan
- tambahkan pengujian unit untuk scrubber residual

## Pengujian
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689894e83b5083288cea3feb355614dd